### PR TITLE
Add Windows support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ lru = "0.18.1"
 md-5 = "0.11.0"
 rand = "0.10.2"
 ratatui = "0.30.2"
-ratatui-image = "11.0.6"
 reqwest = { version = "0.13.4", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
@@ -30,6 +29,16 @@ thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full"] }
 update-informer = "1.3.0"
 url = "2.5.8"
+
+# On Windows there's no standard pkg-config/libchafa install path, and the
+# app never calls into chafa directly (only the crate's native kitty/iterm2/
+# sixel/halfblocks protocols via Picker::from_query_stdio/halfblocks), so the
+# chafa-dyn default feature is dropped for windows builds only.
+[target.'cfg(windows)'.dependencies]
+ratatui-image = { version = "11.0.6", default-features = false, features = ["image-defaults", "crossterm"] }
+
+[target.'cfg(not(windows))'.dependencies]
+ratatui-image = "11.0.6"
 
 [lib]
 name = "moviebox_tui"

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -11,6 +11,71 @@ use crate::tui::{
 use crate::v3::client::MovieBoxClient;
 use update_informer::Check;
 
+/// Strips characters that are illegal in Windows filenames (also invalid or
+/// awkward on macOS/Linux) so downloaded titles never break `fs::write`.
+fn sanitize_filename(name: &str) -> String {
+    let cleaned: String = name
+        .chars()
+        .map(|c| match c {
+            '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => '_',
+            c if c.is_control() => '_',
+            c => c,
+        })
+        .collect();
+
+    let trimmed = cleaned.trim().trim_end_matches(['.', ' ']);
+    let result = if trimmed.is_empty() {
+        "MovieBox-Tui_Stream".to_string()
+    } else {
+        trimmed.to_string()
+    };
+
+    const RESERVED: &[&str] = &[
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7",
+        "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+    if RESERVED.contains(&result.to_uppercase().as_str()) {
+        format!("_{}", result)
+    } else {
+        result
+    }
+}
+
+/// Downloads a (possibly remote) subtitle file to a local temp path.
+///
+/// mpv can load subtitles straight from an HTTP(S) URL, but VLC's
+/// `--sub-file` only accepts a local filesystem path and silently ignores
+/// URLs, so subtitles must be fetched down first for VLC to pick them up.
+async fn download_subtitle_to_temp(url: &str) -> Result<String, String> {
+    let ext = url
+        .rsplit('/')
+        .next()
+        .and_then(|last| last.rsplit_once('.'))
+        .map(|(_, ext)| ext.split(['?', '#']).next().unwrap_or("srt"))
+        .filter(|ext| ext.len() <= 5 && !ext.is_empty())
+        .unwrap_or("srt");
+
+    let bytes = reqwest::get(url)
+        .await
+        .map_err(|e| e.to_string())?
+        .bytes()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let filename = format!(
+        "moviebox-tui_sub_{}.{}",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis(),
+        ext
+    );
+    let path = std::env::temp_dir().join(filename);
+    std::fs::write(&path, &bytes).map_err(|e| e.to_string())?;
+
+    Ok(path.to_string_lossy().into_owned())
+}
+
 pub struct App {
     state: AppState,
     theme: Theme,
@@ -997,24 +1062,50 @@ impl App {
             }
             Action::LaunchMpv(link, subtitle_url) => {
                 use std::process::{Command, Stdio};
-                self.state.toast_message = Some("[ i ] Launching MPV...".to_string());
+                self.state.toast_message = Some("[ i ] Launching VLC...".to_string());
                 self.state.toast_timer = 40;
-                
-                let mut cmd = Command::new("mpv");
-                cmd.arg(&link).stdout(Stdio::null()).stderr(Stdio::null());
-                
-                if let Some(sub) = subtitle_url {
-                    if !sub.is_empty() {
-                        cmd.arg(format!("--sub-file={}", sub));
+
+                // VLC's --sub-file only accepts a local path (unlike mpv,
+                // which can stream subtitles straight from a URL), so fetch
+                // it locally first whenever one was selected.
+                let local_subtitle_path = match subtitle_url.as_deref() {
+                    Some(sub) if !sub.is_empty() => match download_subtitle_to_temp(sub).await {
+                        Ok(path) => Some(path),
+                        Err(e) => {
+                            self.state
+                                .add_log(format!("Failed to download subtitle: {}", e));
+                            None
+                        }
+                    },
+                    _ => None,
+                };
+
+                // VLC is tried first (preferred default); mpv is kept as a
+                // fallback for setups that only have mpv installed.
+                let players: [(&str, &str); 2] = [("vlc", "VLC"), ("mpv", "MPV")];
+                let mut launched = false;
+
+                for (bin, label) in players {
+                    let mut cmd = Command::new(bin);
+                    cmd.arg(&link).stdout(Stdio::null()).stderr(Stdio::null());
+
+                    if let Some(sub_path) = &local_subtitle_path {
+                        cmd.arg(format!("--sub-file={}", sub_path));
+                    }
+
+                    if cmd.spawn().is_ok() {
+                        self.state.add_log(format!("{} started successfully.", label));
+                        launched = true;
+                        break;
                     }
                 }
-                
-                if cmd.spawn().is_ok() {
-                    self.state.add_log("MPV started successfully.".to_string());
-                } else {
-                    self.state.toast_message = Some("[ ! ] Error: mpv player not found in PATH".to_string());
+
+                if !launched {
+                    self.state.toast_message = Some(
+                        "[ ! ] Error: neither vlc nor mpv found in PATH".to_string(),
+                    );
                     self.state.toast_timer = 60;
-                    self.state.add_log("Error starting mpv process. Command failed.".to_string());
+                    self.state.add_log("Error starting player process. Command failed.".to_string());
                 }
             }
             Action::DownloadStream => {
@@ -1031,7 +1122,7 @@ impl App {
                     let ext = "mp4";
                     let filename = format!(
                         "{}_{}.{}",
-                        title.replace(" ", "_").replace("/", "_"),
+                        sanitize_filename(&title.replace(" ", "_")),
                         std::time::SystemTime::now()
                             .duration_since(std::time::UNIX_EPOCH)
                             .unwrap()


### PR DESCRIPTION
## Summary
This project already worked almost out of the box on Windows thanks to the cross-platform crates in use (crossterm, ratatui, arboard, dirs, reqwest/tokio), but a few gaps prevented it from actually building/running there:

- **Build blocker**: `ratatui-image`'s default `chafa-dyn` feature links against `libchafa` via `pkg-config`, which has no standard install path on Windows. This is now disabled for Windows builds only (via `cfg(windows)` target dependency split); the app never calls chafa directly, so kitty/iTerm2/sixel detection and the halfblocks fallback via `Picker::from_query_stdio`/`Picker::halfblocks` still work as before on all platforms.
- **Download filenames**: titles containing characters illegal in Windows filenames (`: < > " | ? *`) or matching reserved device names (`CON`, `PRN`, etc.) would fail to save. Added a small cross-platform sanitizer.
- **Player choice**: added VLC as the preferred default player (tried first), falling back to mpv if VLC isn't installed, since VLC is a more common install on Windows.
- **Subtitles**: subtitle URLs were passed straight to `--sub-file=<url>`, which mpv supports but VLC does not (VLC only accepts local paths and silently ignores remote URLs). Subtitles are now downloaded to a local temp file before being handed to either player.

## Test plan
- [x] Built and ran `moviebox-tui.exe` on Windows 11 (MSVC toolchain) after disabling the chafa feature
- [x] Verified search, browsing, and poster rendering (halfblocks fallback) work in Windows Terminal
- [x] Verified stream playback launches VLC by default, with mpv fallback tested by temporarily removing VLC from PATH
- [x] Verified external subtitle selection now applies correctly in VLC
- [x] Verified downloaded filenames with colons/special characters (e.g. "Movie: Subtitle") save correctly