### PR TITLE
feat: add unit test suite for core modules

### DIFF
--- a/src/providers/moviebox/client.rs
+++ b/src/providers/moviebox/client.rs
@@ -197,3 +197,26 @@ impl MovieBoxClient {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_initialization() {
+        let client = MovieBoxClient::new();
+        assert!(!client.user_agent.is_empty());
+        assert!(!client.client_info.is_empty());
+        assert!(!client.spoofed_ip.is_empty());
+    }
+
+    #[test]
+    fn test_scraper_error_display() {
+        let err = ScraperError::ApiStatus(404);
+        assert_eq!(err.to_string(), "API error status: 404");
+
+        let hosts_err = ScraperError::HostsExhausted;
+        assert_eq!(hosts_err.to_string(), "All hosts exhausted");
+    }
+}
+

--- a/src/providers/moviebox/crypto.rs
+++ b/src/providers/moviebox/crypto.rs
@@ -256,3 +256,59 @@ pub(crate) fn random_spoofed_ip() -> String {
     let d: u8 = rng.random_range(1..254);
     format!("{}.{}.{}", prefix, c, d)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_x_client_token() {
+        let ts = 1609459200;
+        let token = generate_x_client_token(ts);
+        assert!(token.starts_with("1609459200,"));
+        let parts: Vec<&str> = token.split(',').collect();
+        assert_eq!(parts.len(), 2);
+        assert_eq!(parts[0], "1609459200");
+        assert!(!parts[1].is_empty());
+    }
+
+    #[test]
+    fn test_sorted_query_string() {
+        let url = "https://example.com/api?b=2&a=1&c=3";
+        let sorted = sorted_query_string(url);
+        assert_eq!(sorted, "a=1&b=2&c=3");
+
+        let url_no_query = "https://example.com/api";
+        assert_eq!(sorted_query_string(url_no_query), "");
+
+        let url_invalid = "invalid_url";
+        assert_eq!(sorted_query_string(url_invalid), "");
+    }
+
+    #[test]
+    fn test_build_canonical_string() {
+        let url = "https://api.example.com/v1/search?query=test&page=1";
+        let canonical = build_canonical_string("GET", None, None, url, None, 1700000000000);
+        assert!(canonical.contains("/v1/search?page=1&query=test"));
+    }
+
+    #[test]
+    fn test_base64_helpers() {
+        let original = b"hello moviebox";
+        let encoded = b64_encode(original);
+        let decoded = b64_decode(&encoded);
+        assert_eq!(decoded, original);
+
+        let unpadded = "aGVsbG8";
+        let decoded_unpadded = b64_decode(unpadded);
+        assert_eq!(decoded_unpadded, b"hello");
+    }
+
+    #[test]
+    fn test_random_spoofed_ip_format() {
+        let ip = random_spoofed_ip();
+        let parts: Vec<&str> = ip.split('.').collect();
+        assert_eq!(parts.len(), 4);
+    }
+}
+

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2648,3 +2648,53 @@ impl App {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    #[tokio::test]
+    async fn test_app_action_toggle_help() {
+        let mut app = App::new();
+        assert!(!app.state.show_help);
+
+        app.handle_action(Action::ToggleHelp).await;
+        assert!(app.state.show_help);
+
+        app.handle_action(Action::ToggleHelp).await;
+        assert!(!app.state.show_help);
+    }
+
+    #[tokio::test]
+    async fn test_app_action_quit() {
+        let mut app = App::new();
+        let result = app.handle_action(Action::Quit).await;
+        assert_eq!(result, Some(()));
+    }
+
+    #[tokio::test]
+    async fn test_app_key_input_editing_mode() {
+        let mut app = App::new();
+        app.state.input_mode = InputMode::Editing;
+        app.state.search_query.clear();
+
+        // Simulate typing 'm', 'o', 'v', 'i', 'e'
+        for ch in ['m', 'o', 'v', 'i', 'e'] {
+            let key = KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE);
+            app.handle_action(Action::Key(key)).await;
+        }
+        assert_eq!(app.state.search_query, "movie");
+
+        // Simulate Backspace
+        let backspace = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+        app.handle_action(Action::Key(backspace)).await;
+        assert_eq!(app.state.search_query, "movi");
+
+        // Simulate Esc to switch back to normal mode
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        app.handle_action(Action::Key(esc)).await;
+        assert_eq!(app.state.input_mode, InputMode::Normal);
+    }
+}
+

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -13,7 +13,7 @@ pub enum Screen {
     Details,
 }
 
-#[derive(Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub enum DetailsPane {
     #[default]
     Streams,
@@ -21,6 +21,7 @@ pub enum DetailsPane {
     Episodes,
     Languages,
 }
+
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputMode {
@@ -242,3 +243,26 @@ impl Default for AppState {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_app_state_default() {
+        let state = AppState::default();
+        assert_eq!(state.active_screen, Screen::Home);
+        assert_eq!(state.input_mode, InputMode::Normal);
+        assert_eq!(state.details_pane, DetailsPane::Streams);
+        assert!(!state.show_help);
+        assert!(!state.is_loading);
+        assert_eq!(state.search_query, "");
+    }
+
+    #[test]
+    fn test_details_pane_default() {
+        let pane = DetailsPane::default();
+        assert_eq!(pane, DetailsPane::Streams);
+    }
+}
+

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -99,3 +99,23 @@ impl Theme {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_theme_default() {
+        let theme = Theme::default();
+        assert_eq!(theme.border.fg, Some(Color::Rgb(88, 91, 112)));
+        assert_eq!(theme.border_focus.fg, Some(Color::Rgb(137, 180, 250)));
+    }
+
+    #[test]
+    fn test_theme_fallback() {
+        let theme = Theme::fallback();
+        assert_eq!(theme.border.fg, Some(Color::DarkGray));
+        assert_eq!(theme.border_focus.fg, Some(Color::Blue));
+    }
+}
+


### PR DESCRIPTION
Hi @mesamirh,

This PR adds unit test coverage for core modules in `MovieBox-Tui`:

- **Crypto & Network Helpers** (`src/providers/moviebox/crypto.rs`): Tests for signature generation, query sorting, base64 helpers, and IP spoof formatting.
- **API Client** (`src/providers/moviebox/client.rs`): Tests for client initialization and error display strings.
- **State & Theme Defaults** (`src/tui/state.rs`, `src/tui/theme.rs`): Tests for default AppState initialization and theme fallback.
- **App Action Dispatching** (`src/tui/app.rs`): Tests for help modal toggles, quit signals, and editing mode keypresses.

All 14 tests pass cleanly (`cargo test`).
