### PR TITLE
feat(tui): add curated browse views

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ moviebox-tui
 | Command              | Action                                    |
 | -------------------- | ----------------------------------------- |
 | `/discover`, `/home` | Open discovery view                       |
+| `/browse`            | Browse curated, rated, and most-watched views |
 | `/history`           | Show watch history                        |
 | `/movies`            | Browse movies                             |
 | `/shows`, `/tvshows` | Browse series                             |

--- a/src/tui/action.rs
+++ b/src/tui/action.rs
@@ -62,6 +62,8 @@ pub enum Action {
     ShowDownloadSubtitlePopup(serde_json::Value),
     ToggleThemePopup,
     SelectTheme(String),
+    ShowBrowseMenu,
+    SelectBrowse(crate::tui::state::BrowsePreset),
     LaunchMpv(String, Option<String>),
     DownloadStream(Option<String>),
     StartDownload(Option<String>, Option<String>),

--- a/src/tui/app/keyboard.rs
+++ b/src/tui/app/keyboard.rs
@@ -54,6 +54,39 @@ impl App {
             return None;
         }
 
+        if self.state.show_browse_popup {
+            match key.code {
+                KeyCode::Esc => {
+                    self.state.show_browse_popup = false;
+                    self.state.browse_list_state.select(None);
+                }
+                KeyCode::Up => {
+                    let max = crate::tui::state::BrowsePreset::ALL.len().saturating_sub(1);
+                    let next = match self.state.browse_list_state.selected() {
+                        Some(0) | None => max,
+                        Some(index) => index.saturating_sub(1),
+                    };
+                    self.state.browse_list_state.select(Some(next));
+                }
+                KeyCode::Down => {
+                    let max = crate::tui::state::BrowsePreset::ALL.len().saturating_sub(1);
+                    let next = match self.state.browse_list_state.selected() {
+                        Some(index) if index < max => index + 1,
+                        _ => 0,
+                    };
+                    self.state.browse_list_state.select(Some(next));
+                }
+                KeyCode::Enter => {
+                    let index = self.state.browse_list_state.selected().unwrap_or(0);
+                    if let Some(preset) = crate::tui::state::BrowsePreset::ALL.get(index).copied() {
+                        self.action_sender.send(Action::SelectBrowse(preset)).ok();
+                    }
+                }
+                _ => {}
+            }
+            return None;
+        }
+
         if self.state.show_theme_popup {
             match key.code {
                 KeyCode::Esc => {

--- a/src/tui/app/navigation.rs
+++ b/src/tui/app/navigation.rs
@@ -35,6 +35,8 @@ impl App {
         self.state.active_provider = provider;
         self.state.active_screen = Screen::Home;
         self.state.is_homepage_mode = false;
+        self.state.active_browse_preset = None;
+        self.state.browse_metrics.clear();
         self.state.is_tv_mode = false;
         self.state.is_loading = false;
         self.state.is_fetching_streams = false;
@@ -337,6 +339,11 @@ impl App {
                     self.state.show_help = false;
                     return None;
                 }
+                if self.state.show_browse_popup {
+                    self.state.show_browse_popup = false;
+                    self.state.browse_list_state.select(None);
+                    return None;
+                }
                 match self.state.active_screen {
                     Screen::Startup => {}
                     Screen::Home => {
@@ -347,6 +354,8 @@ impl App {
                                 self.state.active_preview_request.wrapping_add(1);
                             self.state.search_poster_protocols.clear();
                             self.state.search_results.clear();
+                            self.state.active_browse_preset = None;
+                            self.state.browse_metrics.clear();
                             self.state.search_error = None;
                             self.state.search_query.clear();
                             self.state.search_suggestions.clear();

--- a/src/tui/app/requests.rs
+++ b/src/tui/app/requests.rs
@@ -30,6 +30,7 @@ impl App {
                         commands.extend(vec![
                             "/discover",
                             "/home",
+                            "/browse",
                             "/history",
                             "/movies",
                             "/shows",
@@ -153,6 +154,8 @@ impl App {
                     self.state.input_mode = InputMode::Normal;
                     self.state.is_loading = false;
                     self.state.is_homepage_mode = false;
+                    self.state.active_browse_preset = None;
+                    self.state.browse_metrics.clear();
                     self.state.active_screen = Screen::Home;
                     self.state.active_subject_id = None;
                     self.state.active_preview_request =
@@ -235,6 +238,26 @@ impl App {
                 }
                 self.prepare_homepage_request(&tab_id, page);
                 self.run_homepage_request(tab_id, page);
+            }
+
+            Action::SelectBrowse(preset) => {
+                if self.state.active_provider != ProviderKind::MovieBox {
+                    self.state.set_status(
+                        "Browse is available only with the MovieBox provider.".to_string(),
+                        180,
+                    );
+                    return None;
+                }
+                self.state.show_browse_popup = false;
+                self.state.active_browse_preset = Some(preset);
+                self.state.browse_list_state.select(None);
+                self.state.search_query.clear();
+                self.action_sender
+                    .send(Action::FetchHomepage {
+                        tab_id: "2".to_string(),
+                        page: 1,
+                    })
+                    .ok();
             }
 
             Action::SearchSuccess {
@@ -470,8 +493,13 @@ impl App {
                     self.state.search_error = None;
                 }
 
-                let extracted_subjects = Self::extract_homepage_subjects(&payload);
+                let extracted_subjects = self
+                    .state
+                    .active_browse_preset
+                    .map(|preset| Self::extract_browse_subjects(&payload, preset))
+                    .unwrap_or_else(|| Self::extract_homepage_subjects(&payload));
                 let count = self.append_homepage_subjects(extracted_subjects);
+                self.sort_browse_results();
 
                 if count > 0 {
                     self.spawn_search_posters(
@@ -498,10 +526,20 @@ impl App {
 
                 self.prepare_image_refresh();
 
-                self.state.set_status(
-                    format!("Found {} discover items", self.state.search_results.len()),
-                    150,
-                );
+                let status = self
+                    .state
+                    .active_browse_preset
+                    .map(|preset| {
+                        format!(
+                            "{} · {} items",
+                            preset.label(),
+                            self.state.search_results.len()
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        format!("Found {} discover items", self.state.search_results.len())
+                    });
+                self.state.set_status(status, 150);
             }
 
             Action::HomepageFailure(request_id, err) => {

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -119,6 +119,7 @@ impl App {
             | Action::CacheCleared(..)
             | Action::ToggleThemePopup
             | Action::SelectTheme(..)
+            | Action::ShowBrowseMenu
             | Action::SetStatus(..)
             | Action::CheckForUpdates
             | Action::UpdateAvailable(..) => {
@@ -152,6 +153,7 @@ impl App {
             | Action::SelectSuggestion { .. }
             | Action::Search { .. }
             | Action::FetchHomepage { .. }
+            | Action::SelectBrowse(..)
             | Action::SearchSuccess { .. }
             | Action::SearchFailure(..)
             | Action::HomepageSuccess { .. }

--- a/src/tui/app/search.rs
+++ b/src/tui/app/search.rs
@@ -3,8 +3,96 @@ use crate::providers::models::{ProviderKind, RequestContext};
 use crate::tui::{
     action::Action,
     overlay::NotificationKind,
-    state::{InputMode, Screen, SearchResult},
+    state::{BrowseMetrics, BrowsePreset, InputMode, Screen, SearchResult},
 };
+
+fn metric_value(item: &serde_json::Value, keys: &[&str]) -> Option<f64> {
+    let mut containers = vec![item];
+    if let Some(metadata) = item.get("metadata") {
+        containers.push(metadata);
+    }
+    if let Some(meta) = item.get("meta") {
+        containers.push(meta);
+    }
+
+    containers.into_iter().find_map(|container| {
+        keys.iter().find_map(|key| {
+            let value = container.get(*key)?;
+            value
+                .as_f64()
+                .or_else(|| value.as_i64().map(|number| number as f64))
+                .or_else(|| value.as_str().and_then(|text| text.parse::<f64>().ok()))
+        })
+    })
+}
+
+fn extract_browse_metrics(item: &serde_json::Value) -> BrowseMetrics {
+    BrowseMetrics {
+        trending: metric_value(
+            item,
+            &["__browse_rank", "imdb_trending", "imdbTrending", "trending"],
+        ),
+        rating: metric_value(
+            item,
+            &["imdbRatingValue", "imdbRate", "imdb_rating", "imdbRating"],
+        ),
+        recent_rating: metric_value(
+            item,
+            &[
+                "imdb_rating_30d",
+                "imdbRating30Days",
+                "imdbRatingLast30Days",
+                "imdb_rating_recent",
+                "imdbRatingValue",
+                "imdbRate",
+            ],
+        ),
+        popularity: metric_value(
+            item,
+            &[
+                "__browse_rank",
+                "imdb_popularity",
+                "imdbPopularity",
+                "popularity",
+                "viewers",
+            ],
+        ),
+    }
+}
+
+fn browse_group_matches(title: &str, preset: BrowsePreset) -> bool {
+    let title = title.to_lowercase();
+    match preset.metric() {
+        crate::tui::state::BrowseMetric::Trending => {
+            title.contains("trending") || title.contains("hot")
+        }
+        crate::tui::state::BrowseMetric::Rating => title.contains("top") || title.contains("rated"),
+        crate::tui::state::BrowseMetric::RecentRating => {
+            title.contains("new") || title.contains("release") || title.contains("recent")
+        }
+        crate::tui::state::BrowseMetric::Popularity => {
+            title.contains("popular") || title.contains("most") || title.contains("watched")
+        }
+    }
+}
+
+fn compare_browse_values(
+    left: Option<f64>,
+    right: Option<f64>,
+    descending: bool,
+) -> std::cmp::Ordering {
+    match (left, right) {
+        (Some(left), Some(right)) => {
+            let order = left
+                .partial_cmp(&right)
+                .unwrap_or(std::cmp::Ordering::Equal);
+            if descending { order.reverse() } else { order }
+        }
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    }
+}
 
 impl App {
     pub(super) fn apply_tv_search_results(&mut self, query: &str, lower_query: &str) {
@@ -81,6 +169,12 @@ impl App {
             self.state.search_query.clear();
             self.state.input_mode = InputMode::Normal;
             self.action_sender.send(Action::ToggleThemePopup).ok();
+            return Some(true);
+        }
+        if lower_query == "/browse" {
+            self.state.search_query.clear();
+            self.state.input_mode = InputMode::Normal;
+            self.action_sender.send(Action::ShowBrowseMenu).ok();
             return Some(true);
         }
         if lower_query == "/toggle-update" {
@@ -175,6 +269,7 @@ impl App {
                 );
                 return Some(true);
             }
+            self.state.active_browse_preset = None;
             self.action_sender
                 .send(Action::FetchHomepage {
                     tab_id: tid.to_string(),
@@ -191,6 +286,8 @@ impl App {
         self.state.active_search_request = self.state.active_search_request.wrapping_add(1);
         self.state.active_preview_request = self.state.active_preview_request.wrapping_add(1);
         self.state.is_homepage_mode = false;
+        self.state.active_browse_preset = None;
+        self.state.browse_metrics.clear();
         self.state.current_page = 1;
         self.state.active_screen = Screen::Home;
         self.state.active_subject_id = None;
@@ -296,6 +393,7 @@ impl App {
         self.state.search_error = None;
         if page == 1 {
             self.state.search_results.clear();
+            self.state.browse_metrics.clear();
             self.state.search_list_state.select(Some(0));
         }
         self.state.search_suggestions.clear();
@@ -474,6 +572,48 @@ impl App {
         extracted_subjects
     }
 
+    pub(super) fn extract_browse_subjects(
+        payload: &serde_json::Value,
+        preset: BrowsePreset,
+    ) -> Vec<serde_json::Value> {
+        let Some(items) = payload.get("items").and_then(|items| items.as_array()) else {
+            return Vec::new();
+        };
+
+        let matching_items: Vec<_> = items
+            .iter()
+            .filter(|item| {
+                item.get("title")
+                    .and_then(|title| title.as_str())
+                    .is_some_and(|title| browse_group_matches(title, preset))
+            })
+            .collect();
+        let groups = if matching_items.is_empty() {
+            items.iter().collect()
+        } else {
+            matching_items
+        };
+
+        let mut subjects = Vec::new();
+        for group in groups {
+            let Some(group_subjects) = group.get("subjects").and_then(|s| s.as_array()) else {
+                continue;
+            };
+            let rank_metric = preset.metric() == crate::tui::state::BrowseMetric::Trending;
+            for (index, subject) in group_subjects.iter().enumerate() {
+                let mut subject = subject.clone();
+                if rank_metric && let Some(subject_object) = subject.as_object_mut() {
+                    subject_object.insert(
+                        "__browse_rank".to_string(),
+                        serde_json::json!((group_subjects.len() - index) as f64),
+                    );
+                }
+                subjects.push(subject);
+            }
+        }
+        subjects
+    }
+
     pub(super) fn append_homepage_subjects(&mut self, subjects: Vec<serde_json::Value>) -> usize {
         let mut count = 0;
         for item in subjects {
@@ -506,8 +646,15 @@ impl App {
                 .and_then(|u| u.as_str())
                 .map(|s| s.to_string());
             let season = item.get("season").and_then(|s| s.as_u64()).unwrap_or(0) as usize;
+            let metrics = extract_browse_metrics(&item);
 
             if let Some(existing) = self.state.search_results.iter_mut().find(|r| r.id == id) {
+                let stored_metrics = self.state.browse_metrics.entry(id.clone()).or_default();
+                stored_metrics.trending = stored_metrics.trending.or(metrics.trending);
+                stored_metrics.rating = stored_metrics.rating.or(metrics.rating);
+                stored_metrics.recent_rating =
+                    stored_metrics.recent_rating.or(metrics.recent_rating);
+                stored_metrics.popularity = stored_metrics.popularity.or(metrics.popularity);
                 if season > existing.season {
                     existing.season = season;
                     existing.title = clean_title;
@@ -541,6 +688,7 @@ impl App {
             }
 
             if !id.is_empty() {
+                self.state.browse_metrics.insert(id.clone(), metrics);
                 self.state.search_results.push(SearchResult {
                     id,
                     title: clean_title,
@@ -555,6 +703,30 @@ impl App {
             }
         }
         count
+    }
+
+    pub(super) fn sort_browse_results(&mut self) {
+        let Some(preset) = self.state.active_browse_preset else {
+            return;
+        };
+        let metrics = self.state.browse_metrics.clone();
+        let metric = preset.metric();
+        let descending = preset.descending();
+        self.state.search_results.sort_by(|left, right| {
+            let left_value = metrics
+                .get(&left.id)
+                .and_then(|values| values.value(metric));
+            let right_value = metrics
+                .get(&right.id)
+                .and_then(|values| values.value(metric));
+            let metric_order = compare_browse_values(left_value, right_value, descending);
+            if left_value.is_none() && right_value.is_none() {
+                metric_order
+            } else {
+                metric_order
+                    .then_with(|| left.title.to_lowercase().cmp(&right.title.to_lowercase()))
+            }
+        });
     }
 
     pub(super) fn spawn_search_posters(&self, results: Vec<(String, Option<String>)>) {
@@ -582,5 +754,90 @@ impl App {
                 });
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_browse_metrics_from_string_and_nested_values() {
+        let item = serde_json::json!({
+            "metadata": {
+                "imdb_trending": "9.2",
+                "imdbRatingValue": "7.2",
+                "imdbRatingLast30Days": 8.7
+            },
+            "imdb_popularity": 74
+        });
+
+        let metrics = extract_browse_metrics(&item);
+        assert_eq!(metrics.trending, Some(9.2));
+        assert_eq!(metrics.recent_rating, Some(8.7));
+        assert_eq!(metrics.popularity, Some(74.0));
+        assert_eq!(metrics.rating, Some(7.2));
+    }
+
+    #[test]
+    fn browse_sort_keeps_unranked_titles_at_the_end() {
+        assert_eq!(
+            compare_browse_values(Some(7.0), Some(8.0), true),
+            std::cmp::Ordering::Greater
+        );
+        assert_eq!(
+            compare_browse_values(Some(7.0), Some(8.0), false),
+            std::cmp::Ordering::Less
+        );
+        assert_eq!(
+            compare_browse_values(Some(7.0), None, true),
+            std::cmp::Ordering::Less
+        );
+    }
+
+    #[test]
+    fn browse_extraction_uses_matching_curated_group() {
+        let payload = serde_json::json!({
+            "items": [
+                {
+                    "title": "Trending in Cinema",
+                    "subjects": [
+                        {"subjectId": "trending-1", "title": "Current hit"}
+                    ]
+                },
+                {
+                    "title": "Top 20 Movies",
+                    "subjects": [
+                        {"subjectId": "top-1", "title": "All-time favorite"}
+                    ]
+                }
+            ]
+        });
+
+        let subjects = App::extract_browse_subjects(&payload, BrowsePreset::TrendingDesc);
+        assert_eq!(subjects.len(), 1);
+        assert_eq!(subjects[0]["subjectId"], "trending-1");
+        assert_eq!(subjects[0]["__browse_rank"], 1.0);
+    }
+
+    #[test]
+    fn popularity_does_not_alias_top_rated_group() {
+        let payload = serde_json::json!({
+            "items": [
+                {
+                    "title": "Top 20 Movies",
+                    "subjects": [{"subjectId": "top-1", "title": "All-time favorite"}]
+                },
+                {
+                    "title": "Most Watched",
+                    "subjects": [{"subjectId": "watched-1", "title": "Most watched"}]
+                }
+            ]
+        });
+
+        let subjects = App::extract_browse_subjects(&payload, BrowsePreset::PopularDesc);
+        assert_eq!(subjects.len(), 1);
+        assert_eq!(subjects[0]["subjectId"], "watched-1");
+        assert!(subjects[0].get("__browse_rank").is_none());
     }
 }

--- a/src/tui/app/system.rs
+++ b/src/tui/app/system.rs
@@ -109,6 +109,7 @@ impl App {
                     self.state.show_help = !self.state.show_help;
                     if self.state.show_help {
                         self.state.show_theme_popup = false;
+                        self.state.show_browse_popup = false;
                         self.state.tv_config_popup = false;
                         self.state.player_picker_popup = false;
                         self.state.subtitle_popup = false;
@@ -126,6 +127,16 @@ impl App {
                         self.state
                             .set_status("Reloading TV playlists...".to_string(), 150);
                         self.reload_tv_playlists();
+                    } else if let Some(preset) = self.state.active_browse_preset {
+                        self.state.is_loading = true;
+                        self.state
+                            .set_status(format!("Reloading {}...", preset.label()), 150);
+                        self.action_sender
+                            .send(Action::FetchHomepage {
+                                tab_id: "2".to_string(),
+                                page: 1,
+                            })
+                            .ok();
                     } else if !query.is_empty() {
                         self.action_sender
                             .send(Action::Search {
@@ -192,6 +203,7 @@ impl App {
                 self.state.image_cache.clear();
                 self.state.search_posters.clear();
                 self.state.search_poster_protocols.clear();
+                self.state.browse_metrics.clear();
                 self.state.preview_cache.clear();
                 self.state.poster_image = None;
                 self.state.poster_protocol = None;
@@ -254,6 +266,23 @@ impl App {
                     }
                 } else {
                     self.state.show_theme_popup = false;
+                }
+            }
+
+            Action::ShowBrowseMenu => {
+                if self.state.is_tv_mode
+                    || self.state.active_provider
+                        != crate::providers::models::ProviderKind::MovieBox
+                {
+                    self.state.set_status(
+                        "Browse is available only with the MovieBox provider.".to_string(),
+                        180,
+                    );
+                } else {
+                    self.reset_transient_overlays();
+                    self.state.show_browse_popup = true;
+                    self.state.browse_list_state.select(Some(0));
+                    self.state.input_mode = crate::tui::state::InputMode::Normal;
                 }
             }
 

--- a/src/tui/app/tv.rs
+++ b/src/tui/app/tv.rs
@@ -5,6 +5,7 @@ impl App {
     pub(super) fn reset_transient_overlays(&mut self) {
         self.state.show_help = false;
         self.state.show_theme_popup = false;
+        self.state.show_browse_popup = false;
         self.state.player_picker_popup = false;
         self.state.player_picker_link = None;
         self.state.player_picker_subtitle = None;
@@ -35,6 +36,8 @@ impl App {
                 self.state.active_preview_request =
                     self.state.active_preview_request.wrapping_add(1);
                 self.state.is_tv_mode = !self.state.is_tv_mode;
+                self.state.active_browse_preset = None;
+                self.state.browse_metrics.clear();
                 self.state.tick_count = 0;
                 self.reset_transient_overlays();
                 self.state.input_mode = crate::tui::state::InputMode::Normal;

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -124,6 +124,10 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
                 Span::styled("Trending & Featured", theme.text),
             ]),
             Line::from(vec![
+                Span::styled("    /browse    ", theme.header),
+                Span::styled("IMDb-ranked movie views", theme.text),
+            ]),
+            Line::from(vec![
                 Span::styled("    /history   ", theme.header),
                 Span::styled("Watch History", theme.text),
             ]),

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -1125,6 +1125,26 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
         );
     }
 
+    if state.show_browse_popup {
+        let items: Vec<String> = crate::tui::state::BrowsePreset::ALL
+            .iter()
+            .map(|preset| preset.label().to_string())
+            .collect();
+        crate::tui::overlay::picker(
+            frame,
+            area,
+            &items,
+            &mut state.browse_list_state,
+            crate::tui::overlay::PickerSpec {
+                title: "Browse Movies",
+                confirm_label: "Open",
+                minimum_width: 42,
+            },
+            theme,
+            state.basic_terminal,
+        );
+    }
+
     if state.player_picker_popup {
         let items = state
             .available_players

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -73,6 +73,90 @@ pub struct SearchResult {
     pub provider: crate::providers::models::ProviderKind,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowseMetric {
+    Trending,
+    Rating,
+    RecentRating,
+    Popularity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrowsePreset {
+    TrendingDesc,
+    TrendingAsc,
+    TopRatedAllTimeDesc,
+    TopRatedAllTimeAsc,
+    TopRatedRecentDesc,
+    TopRatedRecentAsc,
+    PopularDesc,
+    PopularAsc,
+}
+
+impl BrowsePreset {
+    pub const ALL: [Self; 8] = [
+        Self::TrendingDesc,
+        Self::TrendingAsc,
+        Self::TopRatedAllTimeDesc,
+        Self::TopRatedAllTimeAsc,
+        Self::TopRatedRecentDesc,
+        Self::TopRatedRecentAsc,
+        Self::PopularDesc,
+        Self::PopularAsc,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::TrendingDesc => "Trending · High to low",
+            Self::TrendingAsc => "Trending · Low to high",
+            Self::TopRatedAllTimeDesc => "Top Rated · All-time · High to low",
+            Self::TopRatedAllTimeAsc => "Top Rated · All-time · Low to high",
+            Self::TopRatedRecentDesc => "Top Rated · Recent releases · High to low",
+            Self::TopRatedRecentAsc => "Top Rated · Recent releases · Low to high",
+            Self::PopularDesc => "Most Watched · High to low",
+            Self::PopularAsc => "Most Watched · Low to high",
+        }
+    }
+
+    pub fn metric(self) -> BrowseMetric {
+        match self {
+            Self::TrendingDesc | Self::TrendingAsc => BrowseMetric::Trending,
+            Self::TopRatedAllTimeDesc | Self::TopRatedAllTimeAsc => BrowseMetric::Rating,
+            Self::TopRatedRecentDesc | Self::TopRatedRecentAsc => BrowseMetric::RecentRating,
+            Self::PopularDesc | Self::PopularAsc => BrowseMetric::Popularity,
+        }
+    }
+
+    pub fn descending(self) -> bool {
+        matches!(
+            self,
+            Self::TrendingDesc
+                | Self::TopRatedAllTimeDesc
+                | Self::TopRatedRecentDesc
+                | Self::PopularDesc
+        )
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BrowseMetrics {
+    pub trending: Option<f64>,
+    pub rating: Option<f64>,
+    pub recent_rating: Option<f64>,
+    pub popularity: Option<f64>,
+}
+
+impl BrowseMetrics {
+    pub fn value(self, metric: BrowseMetric) -> Option<f64> {
+        match metric {
+            BrowseMetric::Trending => self.trending,
+            BrowseMetric::Rating => self.rating,
+            BrowseMetric::RecentRating => self.recent_rating,
+            BrowseMetric::Popularity => self.popularity,
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct SubjectStreamPool {
     pub episode_index: std::collections::HashMap<(usize, usize), Vec<serde_json::Value>>,
@@ -135,6 +219,10 @@ pub struct AppState {
     pub show_theme_popup: bool,
     pub active_theme_kind: String,
     pub theme_list_state: ListState,
+    pub show_browse_popup: bool,
+    pub browse_list_state: ListState,
+    pub active_browse_preset: Option<BrowsePreset>,
+    pub browse_metrics: std::collections::HashMap<String, BrowseMetrics>,
 
     pub poster_protocol: Option<(ratatui::layout::Rect, ratatui_image::protocol::Protocol)>,
     pub image_picker: Option<ratatui_image::picker::Picker>,
@@ -253,6 +341,10 @@ impl Default for AppState {
             active_theme_kind: String::new(),
             show_theme_popup: false,
             theme_list_state: ListState::default(),
+            show_browse_popup: false,
+            browse_list_state: ListState::default(),
+            active_browse_preset: None,
+            browse_metrics: std::collections::HashMap::new(),
             poster_protocol: None,
             image_picker: None,
             image_supported: crate::tui::terminal::should_query_images(),


### PR DESCRIPTION
Related #56

## What changed

Add a `/browse` menu with keyboard-selectable ascending and descending views for Trending, Top Rated (all-time and recent releases), and Most Watched titles. The menu reuses the existing homepage payload, selects matching curated groups, sorts by the rating/viewer fields the client actually receives, and clears browse state when returning to search/history/provider views.

## API scope

The current mobile payload exposes `imdbRatingValue`/`imdbRate` and `viewers`, but it does not expose numeric `imdb_trending`, `imdb_rating_30d`, or `imdb_popularity` fields. The implementation therefore uses server section order for Trending, IMDb rating for rated views, and viewers for Most Watched; it does not fabricate missing metrics. “Recent” refers to the API’s recent-release groups, sorted by their available rating.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked` (4 tests)
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo check --locked`
