### PR TITLE
feat: add favorites for movies and series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- **Favorites**:
+  - Added a Favorites feature for starring whole movies and series (`src/favorites.rs`, `favorites.json`), independent of watch history and unaffected by `/clear-cache`.
+  - Added `*` on the Home screen and `f` / `F` on the Details screen to toggle a title's favorite status, with a `★` indicator on favorited rows and a `[f] Favorite` / `[f] Unfavorite` hint on the Details screen.
+  - Added an arrow-navigable Favorites row on the landing screen (Streaming and Addon modes) showing up to 5 recently-starred titles, with a `+N more — /favorites` overflow link; `Down` from the search bar focuses the row, `Enter` opens the selected title, `Esc` releases focus.
+  - Added the `/favorites` slash command, mirroring `/history`, to load the full starred list into the results view; `*` unstars the selected row there.
+  - Added mouse support for the landing Favorites row (select/open rows, open the full list via the overflow line).
+  - Extracted cross-provider title-identity matching into `SubjectIdentity` (`src/models.rs`), now shared by watch history and Favorites so remakes, cross-provider duplicates, and movie/series title collisions are deduplicated identically.
+
 ## [0.1.13] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Favorites**:
   - Added a Favorites feature for starring whole movies and series (`src/favorites.rs`, `favorites.json`), independent of watch history and unaffected by `/clear-cache`.
   - Added `*` on the Home screen and `f` / `F` on the Details screen to toggle a title's favorite status, with a `★` indicator on favorited rows and a `[f] Favorite` / `[f] Unfavorite` hint on the Details screen.
-  - Added an arrow-navigable Favorites row on the landing screen (Streaming and Addon modes) showing up to 5 recently-starred titles, with a `+N more — /favorites` overflow link; `Down` from the search bar focuses the row, `Enter` opens the selected title, `Esc` releases focus.
+  - Added an arrow-navigable Favorites row on the landing screen (Streaming and Addon modes) showing up to 5 recently-starred titles, with a `+N more • /favorites` overflow link; `Down` from the search bar focuses the row, `Enter` opens the selected title, `Esc` releases focus.
   - Added the `/favorites` slash command, mirroring `/history`, to load the full starred list into the results view; `*` unstars the selected row there.
   - Added mouse support for the landing Favorites row (select/open rows, open the full list via the overflow line).
   - Extracted cross-provider title-identity matching into `SubjectIdentity` (`src/models.rs`), now shared by watch history and Favorites so remakes, cross-provider duplicates, and movie/series title collisions are deduplicated identically.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Searching and watching media through web browsers often means dealing with heavy
 - **Addon Mode:** Install community HTTP addon manifests for custom catalog metadata (Cinemeta, Anime Kitsu) and direct stream resolution.
 - **Smooth Video Playback:** Plays directly in **mpv**, **VLC**, or **IINA** using your computer's hardware for smooth video.
 - **Easy Downloads:** Download single episodes or entire seasons with one keypress. Completed episodes are skipped automatically.
+- **Favorites:** Star any movie or series with `*` (or `f` on the details screen) and reach it instantly from a dedicated row on the home screen, or view the full list with `/favorites`.
 - **Simple Terminal Interface:** Full keyboard and mouse support, beautiful color themes, and movie poster art.
 
 ## Installation

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ interval, forwarding them into the action channel (capacity 128).
 - `addons_config.json` — installed HTTP community addons in the config dir.
 - `tv_config.json` — user M3U playlist sources (URLs or file paths) in the config dir.
 - `history.json` — watch history in the system data dir.
-- `favorites.json` — starred titles in the system data dir, independent of `history.json`.
+- `favorites.json`: starred titles in the system data dir, independent of `history.json`.
 - `playback/` — temporary playback states for session crash/kill reconciliation in the system data dir.
 - `scripts/` — bundled player scripts (`moviebox_tracker.lua`) in the system data dir.
 - Cache lives under the system cache dir, keyed per provider.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,9 +14,11 @@ src/
   cache.rs                      disk cache: provider-namespaced, TTL'd, atomic writes
   config.rs                     Config load/save (config.json)
   download.rs                   download engine (resume, ranges, segments, retry)
+  favorites.rs                  starred-titles persistence (favorites.json)
   history.rs                    watch history persistence
   logging.rs                    file logging (rotation, sanitization)
-  models.rs                     shared domain models (SearchResult, BrowseMetrics, StreamPool, Notification)
+  models.rs                     shared domain models (SearchResult, BrowseMetrics, StreamPool,
+                                Notification, SubjectIdentity)
   player.rs                     player detection (OnceLock) and command construction (mpv/VLC/IINA/Android)
   providers/
     mod.rs                      provider module tree
@@ -29,7 +31,8 @@ src/
     addons/                     Community HTTP addons provider
     tv/                         Live TV / IPTV provider (M3U parser and models)
   service.rs                    MovieBoxService headless engine (search, details, streams, captions)
-  updater.rs                    GitHub release update check
+  updater/                      GitHub release update check (mod, check, download, verify,
+                                extract, apply, artifact)
   tui/
     app/                        the application object and all behavior
       mod.rs                    App struct, App::new, helpers
@@ -40,6 +43,7 @@ src/
                                 provider search dispatch, poster prefetch
       playback.rs               player launching + playback actions
       download.rs               download orchestration actions
+      favorites.rs              favorite toggle/open actions, /favorites virtual list
       requests.rs               suggest/history/homepage/details/preview/
                                 episode-stream actions
       navigation.rs             list navigation, submit actions, provider helpers
@@ -111,6 +115,7 @@ interval, forwarding them into the action channel (capacity 128).
 - `addons_config.json` — installed HTTP community addons in the config dir.
 - `tv_config.json` — user M3U playlist sources (URLs or file paths) in the config dir.
 - `history.json` — watch history in the system data dir.
+- `favorites.json` — starred titles in the system data dir, independent of `history.json`.
 - `playback/` — temporary playback states for session crash/kill reconciliation in the system data dir.
 - `scripts/` — bundled player scripts (`moviebox_tracker.lua`) in the system data dir.
 - Cache lives under the system cache dir, keyed per provider.

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,7 +24,7 @@ macOS `~/Library/Application Support/moviebox-tui`, Linux `~/.config/moviebox-tu
 - `addons_config.json` — list of installed HTTP addons in the config directory (see [addons-mode.md](addons-mode.md)).
 - `tv_config.json` — list of M3U playlist sources in the config directory (see [tv-mode.md](tv-mode.md)).
 - `history.json` — watch history in the system data directory (`dirs::data_dir()/moviebox-tui/`).
-- `favorites.json` — starred titles in the system data directory. Independent of `history.json`; clearing watch history or running `/clear-cache` never touches it.
+- `favorites.json`: starred titles in the system data directory. Independent of `history.json`; clearing watch history or running `/clear-cache` never touches it.
 - `playback/` — temporary playback states in the system data directory for resilient progress tracking.
 - `scripts/` — bundled player scripts (`moviebox_tracker.lua`) in the system data directory.
 - `iptv_cache/` — legacy TV image cache directory that `ClearCache` still removes.

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,7 @@ macOS `~/Library/Application Support/moviebox-tui`, Linux `~/.config/moviebox-tu
 - `addons_config.json` — list of installed HTTP addons in the config directory (see [addons-mode.md](addons-mode.md)).
 - `tv_config.json` — list of M3U playlist sources in the config directory (see [tv-mode.md](tv-mode.md)).
 - `history.json` — watch history in the system data directory (`dirs::data_dir()/moviebox-tui/`).
+- `favorites.json` — starred titles in the system data directory. Independent of `history.json`; clearing watch history or running `/clear-cache` never touches it.
 - `playback/` — temporary playback states in the system data directory for resilient progress tracking.
 - `scripts/` — bundled player scripts (`moviebox_tracker.lua`) in the system data directory.
 - `iptv_cache/` — legacy TV image cache directory that `ClearCache` still removes.

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -56,7 +56,7 @@ MovieBox-TUI is designed for fast keyboard navigation with complete mouse suppor
 | **Click suggestion item** | Search for that suggestion immediately |
 | **Click search result row** | Select item and load preview; click again to open full details |
 | **Click Favorites row (landing)** | Select a starred title; click again to open it |
-| **Click "+N more — /favorites"** | Open the full favorites list |
+| **Click "+N more • /favorites"** | Open the full favorites list |
 | **Click audio / season / episode / stream** | Switch audio language, change season, select episode, or start playback |
 | **Click footer buttons** | Switch provider / mode, open help (`[?]`), or quit (`[q]`) |
 | **Click modal buttons** | Choose a theme, subtitles, player, or confirm actions |

--- a/docs/controls.md
+++ b/docs/controls.md
@@ -24,8 +24,11 @@ MovieBox-TUI is designed for fast keyboard navigation with complete mouse suppor
 - **`o`**: Open player selection picker for the current stream.
 - **`d`**: Download current episode or full season batch.
 - **`r`**: Refresh search results / stream list.
+- **`*`**: Favorite / unfavorite the selected title on the Home screen.
+- **`f`**: Favorite / unfavorite the open title on the Details screen.
 - **`/browse`**: Open curated browse categories (Trending, Popular, Top Rated, etc.).
 - **`/history`**: Open watch history.
+- **`/favorites`**: Open your starred titles.
 
 ### TV Mode (Live IPTV)
 - **`Enter`**: Play selected TV channel immediately.
@@ -40,7 +43,10 @@ MovieBox-TUI is designed for fast keyboard navigation with complete mouse suppor
 - **`o`**: Open player selection picker for the stream.
 - **`d`**: Download HTTP stream release.
 - **`r`**: Refresh addon catalog search results.
+- **`*`**: Favorite / unfavorite the selected title on the Home screen.
+- **`f`**: Favorite / unfavorite the open title on the Details screen.
 - **`/browse`**: Browse curated addon catalogs (Top Movies, Top Series, Top Rated).
+- **`/favorites`**: Open your starred titles.
 
 ## Mouse Controls
 
@@ -49,6 +55,8 @@ MovieBox-TUI is designed for fast keyboard navigation with complete mouse suppor
 | **Click search bar** | Enter search input mode |
 | **Click suggestion item** | Search for that suggestion immediately |
 | **Click search result row** | Select item and load preview; click again to open full details |
+| **Click Favorites row (landing)** | Select a starred title; click again to open it |
+| **Click "+N more — /favorites"** | Open the full favorites list |
 | **Click audio / season / episode / stream** | Switch audio language, change season, select episode, or start playback |
 | **Click footer buttons** | Switch provider / mode, open help (`[?]`), or quit (`[q]`) |
 | **Click modal buttons** | Choose a theme, subtitles, player, or confirm actions |
@@ -62,6 +70,7 @@ Type these commands directly into the search bar:
 | :--- | :--- | :--- |
 | `/browse` | Streaming / Addon | Browse curated views (Trending, Popular) or Addon catalogs (Top Movies, Top Series) |
 | `/history` | Streaming / Addon | View watch history with latest progress |
+| `/favorites` | Streaming / Addon | View all starred titles |
 | `/list` | TV | View live TV channels |
 | `/config` | TV / Addon | Manage IPTV playlists (TV Mode) or configure HTTP addons (Addon Mode) |
 | `/enable-streaming` | All | Enable Streaming Mode navigation in bottom dock |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -8,8 +8,8 @@ responsibility.
 src/
   main.rs            Entry point. Logging init, panic hook, raw mode, alternate
                      screen, TerminalGuard, App::new + App::run.
-  lib.rs             Crate root: declares pub mod cache/config/download/history/
-                     logging/models/player/providers/service/tui/updater.
+  lib.rs             Crate root: declares pub mod cache/config/download/favorites/
+                     history/logging/models/player/providers/service/tui/updater.
 
   cache.rs           Disk cache: provider-namespaced directories, TTL expiry,
                      atomic temp-file writes, payload validation, background purge.
@@ -22,6 +22,9 @@ src/
                      HTTP ranges, optional multi-segment download, retries, cancel
                      via an AtomicBool, Windows-safe file stems.
 
+  favorites.rs       Starred titles: read/write favorites.json, whole-title identity
+                     dedupe via SubjectIdentity, no cap.
+
   history.rs         Watch history: read/write history.json, dedupe exact
                      provider/subject/episode entries, cap 100.
 
@@ -29,7 +32,9 @@ src/
                      MOVIEBOX_LOG level, URL/path sanitization for sharing.
 
   models.rs          Pure domain data models: SearchResult, BrowseMetric,
-                     BrowsePreset, BrowseMetrics, SubjectStreamPool, Notification.
+                     BrowsePreset, BrowseMetrics, SubjectStreamPool, Notification,
+                     SubjectIdentity (cross-provider identity rules shared by
+                     history and favorites).
 
   player.rs          Player detection (OnceLock) and command construction for
                      mpv / VLC / IINA / Android intent, subtitle args, headers,
@@ -62,7 +67,14 @@ src/
                      engine (suggest, search, details, homepage, resolutions,
                      captions, subtitle download, path resolution).
 
-  updater.rs         GitHub release update check.
+  updater/           GitHub release update check.
+    mod.rs           Module declarations, re-exports, perform_self_update orchestration.
+    check.rs         GitHub release API query (with redirect fallback) and version compare.
+    download.rs      Release asset download (https-only) with retry.
+    verify.rs        SHA-256 hashing and sha256sums parsing for artifact verification.
+    extract.rs       tar.gz / archive extraction for the staged binary.
+    apply.rs         Swap in the new binary, install-environment detection, restart.
+    artifact.rs      Release/ReleaseAsset types, target-platform matching.
 
   tui/
     action.rs        The Action enum: every UI event/message (input, network
@@ -95,6 +107,8 @@ src/
     playback.rs      handle_playback: play/subtitle/picker/launch/crash actions
                      + launch_player.
     download.rs      handle_download: download orchestration + start_resilient_download.
+    favorites.rs     handle_favorites: toggle/open favorite actions, /favorites virtual
+                     list builder.
     navigation.rs    handle_navigation + provider/nav helpers.
     keyboard.rs      handle_key: raw key-event handling.
     mouse.rs         handle_mouse: mouse click routing and hitboxes across screens,

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,15 +40,32 @@ impl Default for Config {
 
 pub const APP_NAME: &str = "moviebox-tui";
 
+/// Test-only escape hatch: several tests exercise `HistoryManager`/
+/// `FavoritesManager`/`Config` save paths directly, which write to whatever
+/// these functions return with no other isolation. Without this override
+/// those saves land on the real, shared config/data directories — on a
+/// machine where the app is also installed for actual use, that silently
+/// overwrites real user data with test fixtures. Set `MOVIEBOX_CONFIG_DIR`
+/// / `MOVIEBOX_DATA_DIR` to a throwaway directory before running `cargo
+/// test` to avoid this; production behavior (unset) is unchanged.
 pub fn config_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("MOVIEBOX_CONFIG_DIR") {
+        return Some(PathBuf::from(dir));
+    }
     dirs::config_dir().map(|dir| dir.join(APP_NAME))
 }
 
 pub fn data_dir() -> Option<PathBuf> {
+    if let Ok(dir) = std::env::var("MOVIEBOX_DATA_DIR") {
+        return Some(PathBuf::from(dir));
+    }
     dirs::data_dir().map(|dir| dir.join(APP_NAME))
 }
 
 pub fn cache_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("MOVIEBOX_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
     dirs::cache_dir()
         .map(|dir| dir.join(APP_NAME))
         .unwrap_or_else(|| std::env::temp_dir().join(APP_NAME))

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,10 @@ pub fn history_path() -> Option<PathBuf> {
     data_dir().map(|dir| dir.join("history.json"))
 }
 
+pub fn favorites_path() -> Option<PathBuf> {
+    data_dir().map(|dir| dir.join("favorites.json"))
+}
+
 pub fn load() -> Config {
     config_path()
         .and_then(|p| std::fs::read_to_string(p).ok())

--- a/src/favorites.rs
+++ b/src/favorites.rs
@@ -1,0 +1,321 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FavoriteItem {
+    pub provider: String,
+    pub subject_id: String,
+    pub title: String,
+    pub cover_url: Option<String>,
+    pub stype: i64,
+    pub release_year: String,
+    pub added_at: u64,
+}
+
+impl FavoriteItem {
+    pub fn identity(&self) -> crate::models::SubjectIdentity<'_> {
+        crate::models::SubjectIdentity {
+            provider: &self.provider,
+            subject_id: &self.subject_id,
+            title: &self.title,
+            stype: self.stype,
+            release_year: &self.release_year,
+        }
+    }
+}
+
+#[derive(Default, Clone, Serialize, Deserialize)]
+pub struct FavoritesManager {
+    #[serde(default)]
+    pub items: Vec<FavoriteItem>,
+}
+
+impl FavoritesManager {
+    pub fn new() -> Self {
+        match Self::favorites_file_path() {
+            Some(path) => Self::load_from_path(&path),
+            None => Self::default(),
+        }
+    }
+
+    fn favorites_file_path() -> Option<PathBuf> {
+        crate::config::favorites_path()
+    }
+
+    pub fn load_from_path(path: &Path) -> Self {
+        if path.exists() {
+            if let Ok(content) = fs::read_to_string(path) {
+                if let Ok(manager) = serde_json::from_str::<Self>(&content) {
+                    return manager;
+                }
+            }
+            let _ = fs::remove_file(path);
+        }
+        Self::default()
+    }
+
+    pub fn save(&self) {
+        if let Some(path) = Self::favorites_file_path() {
+            self.save_to_path(&path);
+        }
+    }
+
+    pub fn save_to_path(&self, path: &Path) {
+        if let Ok(content) = serde_json::to_string(self) {
+            if let Err(error) = crate::cache::atomic_write_file(path, content.as_bytes()) {
+                log::warn!("failed to save favorites: {error}");
+            }
+        }
+    }
+
+    pub fn is_favorite(&self, identity: &crate::models::SubjectIdentity<'_>) -> bool {
+        self.items
+            .iter()
+            .any(|item| item.identity().matches(identity))
+    }
+
+    /// Toggles the given item and returns `true` if it is now favorited,
+    /// `false` if it was just removed.
+    pub fn toggle(&mut self, item: FavoriteItem) -> bool {
+        let now_favorited = if let Some(pos) = self
+            .items
+            .iter()
+            .position(|existing| existing.identity().matches(&item.identity()))
+        {
+            self.items.remove(pos);
+            false
+        } else {
+            self.items.push(item);
+            true
+        };
+        self.save();
+        now_favorited
+    }
+
+    pub fn remove(&mut self, identity: &crate::models::SubjectIdentity<'_>) {
+        self.items.retain(|item| !item.identity().matches(identity));
+        self.save();
+    }
+
+    pub fn clear(&mut self) {
+        self.items.clear();
+        self.save();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_item(
+        provider: &str,
+        subject_id: &str,
+        title: &str,
+        stype: i64,
+        release_year: &str,
+    ) -> FavoriteItem {
+        FavoriteItem {
+            provider: provider.to_string(),
+            subject_id: subject_id.to_string(),
+            title: title.to_string(),
+            cover_url: None,
+            stype,
+            release_year: release_year.to_string(),
+            added_at: 1700000000,
+        }
+    }
+
+    #[test]
+    fn test_toggle_idempotency() {
+        let mut manager = FavoritesManager::default();
+        let item = dummy_item("moviebox", "mb_1", "Dune", 1, "2021");
+
+        assert!(manager.toggle(item.clone()));
+        assert_eq!(manager.items.len(), 1);
+
+        assert!(!manager.toggle(item.clone()));
+        assert!(manager.items.is_empty());
+
+        assert!(manager.toggle(item));
+        assert_eq!(manager.items.len(), 1);
+    }
+
+    #[test]
+    fn test_is_favorite_identity_dedup() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_1", "Breaking Bad", 2, "2008"));
+
+        let target = crate::models::SubjectIdentity {
+            provider: "moviebox",
+            subject_id: "mb_1",
+            title: "Breaking Bad",
+            stype: 2,
+            release_year: "2008",
+        };
+        assert!(manager.is_favorite(&target));
+
+        let different_series = crate::models::SubjectIdentity {
+            provider: "moviebox",
+            subject_id: "mb_2",
+            title: "Breaking Bad",
+            stype: 1,
+            release_year: "2008",
+        };
+        assert!(!manager.is_favorite(&different_series));
+    }
+
+    #[test]
+    fn test_remakes_with_different_years_are_distinct() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "", "Halloween", 1, "1978"));
+
+        let remake = crate::models::SubjectIdentity {
+            provider: "moviebox",
+            subject_id: "",
+            title: "Halloween",
+            stype: 1,
+            release_year: "2018",
+        };
+        assert!(!manager.is_favorite(&remake));
+    }
+
+    #[test]
+    fn test_movie_vs_series_same_title_distinct() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_home_1", "Home", 1, "2015"));
+
+        let series = crate::models::SubjectIdentity {
+            provider: "moviebox",
+            subject_id: "mb_home_2",
+            title: "Home",
+            stype: 2,
+            release_year: "2020",
+        };
+        assert!(!manager.is_favorite(&series));
+    }
+
+    #[test]
+    fn test_same_title_across_providers_distinct() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_1", "Dune", 1, "2021"));
+
+        let addon = crate::models::SubjectIdentity {
+            provider: "addons",
+            subject_id: "tt1160419",
+            title: "Dune",
+            stype: 1,
+            release_year: "2021",
+        };
+        assert!(!manager.is_favorite(&addon));
+    }
+
+    #[test]
+    fn test_empty_subject_id_fallback() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "", "Inception", 1, "2010"));
+
+        let same = crate::models::SubjectIdentity {
+            provider: "moviebox",
+            subject_id: "",
+            title: "Inception",
+            stype: 1,
+            release_year: "2010",
+        };
+        assert!(manager.is_favorite(&same));
+    }
+
+    #[test]
+    fn test_unstar_removal() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_1", "Dune", 1, "2021"));
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_2", "Arrival", 1, "2016"));
+
+        manager.remove(&crate::models::SubjectIdentity {
+            provider: "moviebox",
+            subject_id: "mb_1",
+            title: "Dune",
+            stype: 1,
+            release_year: "2021",
+        });
+
+        assert_eq!(manager.items.len(), 1);
+        assert_eq!(manager.items[0].subject_id, "mb_2");
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_1", "Dune", 1, "2021"));
+        manager.clear();
+        assert!(manager.items.is_empty());
+    }
+
+    #[test]
+    fn test_persistence_roundtrip() {
+        let temp_dir = std::env::temp_dir().join(format!(
+            "mb_test_favorites_{}_roundtrip",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let path = temp_dir.join("favorites.json");
+
+        let mut manager = FavoritesManager::default();
+        manager
+            .items
+            .push(dummy_item("moviebox", "mb_1", "Dune", 1, "2021"));
+        manager.save_to_path(&path);
+
+        let loaded = FavoritesManager::load_from_path(&path);
+        assert_eq!(loaded.items.len(), 1);
+        assert_eq!(loaded.items[0].subject_id, "mb_1");
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_corrupt_file_recovery() {
+        let temp_dir =
+            std::env::temp_dir().join(format!("mb_test_favorites_{}_corrupt", std::process::id()));
+        std::fs::create_dir_all(&temp_dir).unwrap();
+        let path = temp_dir.join("favorites.json");
+        std::fs::write(&path, "not valid json").unwrap();
+
+        let loaded = FavoritesManager::load_from_path(&path);
+        assert!(loaded.items.is_empty());
+        assert!(!path.exists());
+
+        let _ = std::fs::remove_dir_all(&temp_dir);
+    }
+
+    #[test]
+    fn test_no_cap_on_favorites_count() {
+        let mut manager = FavoritesManager::default();
+        for i in 0..250 {
+            manager.items.push(dummy_item(
+                "moviebox",
+                &format!("mb_{i}"),
+                "Title",
+                1,
+                "2020",
+            ));
+        }
+        assert_eq!(manager.items.len(), 250);
+    }
+}

--- a/src/history.rs
+++ b/src/history.rs
@@ -23,6 +23,16 @@ pub struct WatchHistoryItem {
 }
 
 impl WatchHistoryItem {
+    pub fn identity(&self) -> crate::models::SubjectIdentity<'_> {
+        crate::models::SubjectIdentity {
+            provider: &self.provider,
+            subject_id: &self.subject_id,
+            title: &self.title,
+            stype: self.stype,
+            release_year: &self.release_year,
+        }
+    }
+
     pub fn is_in_progress(&self) -> bool {
         if self.completed {
             return false;
@@ -188,36 +198,7 @@ impl HistoryManager {
     }
 
     pub fn is_same_show(a: &WatchHistoryItem, b: &WatchHistoryItem) -> bool {
-        if a.stype != b.stype {
-            return false;
-        }
-
-        let prov_a = crate::providers::models::ProviderKind::parse(&a.provider);
-        let prov_b = crate::providers::models::ProviderKind::parse(&b.provider);
-        let same_provider = match (prov_a, prov_b) {
-            (Some(pa), Some(pb)) => pa == pb,
-            _ => a.provider.trim().eq_ignore_ascii_case(b.provider.trim()),
-        };
-
-        if !same_provider {
-            return false;
-        }
-
-        if !a.subject_id.is_empty() && !b.subject_id.is_empty() {
-            return a.subject_id == b.subject_id;
-        }
-
-        let clean_a = crate::providers::moviebox::clean_moviebox_title(&a.title);
-        let clean_b = crate::providers::moviebox::clean_moviebox_title(&b.title);
-        if !clean_a.is_empty() && clean_a.eq_ignore_ascii_case(&clean_b) {
-            let year_a = a.release_year.trim();
-            let year_b = b.release_year.trim();
-            if !year_a.is_empty() && !year_b.is_empty() {
-                return year_a == year_b;
-            }
-            return true;
-        }
-        false
+        a.identity().matches(&b.identity())
     }
 
     fn hydrate_watched_index(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache;
 pub mod config;
 pub mod download;
+pub mod favorites;
 pub mod history;
 pub mod logging;
 pub mod models;

--- a/src/models.rs
+++ b/src/models.rs
@@ -3,6 +3,56 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
+/// Cross-provider identity rules shared by watch history and favorites: same
+/// `stype`, same provider (canonicalized via `ProviderKind::parse`), then
+/// `subject_id` if both are non-empty, else cleaned title plus release year.
+#[derive(Debug, Clone, Copy)]
+pub struct SubjectIdentity<'a> {
+    pub provider: &'a str,
+    pub subject_id: &'a str,
+    pub title: &'a str,
+    pub stype: i64,
+    pub release_year: &'a str,
+}
+
+impl<'a> SubjectIdentity<'a> {
+    pub fn matches(&self, other: &SubjectIdentity<'_>) -> bool {
+        if self.stype != other.stype {
+            return false;
+        }
+
+        let prov_a = crate::providers::models::ProviderKind::parse(self.provider);
+        let prov_b = crate::providers::models::ProviderKind::parse(other.provider);
+        let same_provider = match (prov_a, prov_b) {
+            (Some(pa), Some(pb)) => pa == pb,
+            _ => self
+                .provider
+                .trim()
+                .eq_ignore_ascii_case(other.provider.trim()),
+        };
+
+        if !same_provider {
+            return false;
+        }
+
+        if !self.subject_id.is_empty() && !other.subject_id.is_empty() {
+            return self.subject_id == other.subject_id;
+        }
+
+        let clean_a = crate::providers::moviebox::clean_moviebox_title(self.title);
+        let clean_b = crate::providers::moviebox::clean_moviebox_title(other.title);
+        if !clean_a.is_empty() && clean_a.eq_ignore_ascii_case(&clean_b) {
+            let year_a = self.release_year.trim();
+            let year_b = other.release_year.trim();
+            if !year_a.is_empty() && !year_b.is_empty() {
+                return year_a == year_b;
+            }
+            return true;
+        }
+        false
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
     pub id: String,

--- a/src/tui/action.rs
+++ b/src/tui/action.rs
@@ -144,4 +144,7 @@ pub enum Action {
     ReconcileHistory,
     PlayerCrashed(Option<i32>, String),
     PlayerExited,
+    ToggleFavorite,
+    ShowFavorites,
+    OpenFavorite(usize),
 }

--- a/src/tui/app/favorites.rs
+++ b/src/tui/app/favorites.rs
@@ -1,0 +1,252 @@
+use super::App;
+use crate::providers::models::ProviderKind;
+use crate::tui::{
+    action::Action,
+    overlay::NotificationKind,
+    state::{InputMode, Screen, SearchResult},
+};
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+impl App {
+    pub(super) async fn handle_favorites(&mut self, action: Action) -> Option<()> {
+        match action {
+            Action::ToggleFavorite => {
+                self.toggle_current_favorite();
+            }
+            Action::ShowFavorites => {
+                self.load_favorites_virtual_list();
+            }
+            Action::OpenFavorite(index) => {
+                self.open_favorite(index);
+            }
+            _ => return None,
+        }
+        None
+    }
+
+    fn current_favorite_candidate(&self) -> Option<crate::favorites::FavoriteItem> {
+        match self.state.active_screen {
+            Screen::Details => {
+                let subject_id = self.state.active_subject_id.clone()?;
+                let details = self.state.selected_details.as_ref()?;
+                let provider = self.current_subject_provider().cache_key().to_string();
+                let raw_title = details
+                    .get("title")
+                    .or_else(|| details.get("name"))
+                    .and_then(|t| t.as_str())
+                    .unwrap_or_default();
+                let title = crate::providers::moviebox::clean_moviebox_title(raw_title);
+                let stype = crate::tui::state::stype(details);
+                let release_year = details
+                    .get("releaseDate")
+                    .or_else(|| details.get("year"))
+                    .or_else(|| details.get("releaseInfo"))
+                    .and_then(|y| y.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let cover_url = details
+                    .get("cover")
+                    .and_then(|c| c.get("url"))
+                    .and_then(|u| u.as_str())
+                    .map(|s| s.to_string());
+                Some(crate::favorites::FavoriteItem {
+                    provider,
+                    subject_id,
+                    title,
+                    cover_url,
+                    stype,
+                    release_year,
+                    added_at: now_secs(),
+                })
+            }
+            Screen::Home => {
+                if self.state.favorites_focus {
+                    let idx = self.state.favorites_landing_state.selected()?;
+                    self.state
+                        .favorites_landing_items()
+                        .get(idx)
+                        .map(|item| (*item).clone())
+                } else {
+                    let idx = self.state.search_list_state.selected()?;
+                    let res = self.state.search_results.get(idx)?;
+                    if res.stype == 3 {
+                        return None;
+                    }
+                    Some(crate::favorites::FavoriteItem {
+                        provider: res.provider.cache_key().to_string(),
+                        subject_id: res.id.clone(),
+                        title: res.title.clone(),
+                        cover_url: res.cover_url.clone(),
+                        stype: res.stype,
+                        release_year: res.release_year.clone(),
+                        added_at: now_secs(),
+                    })
+                }
+            }
+        }
+    }
+
+    fn toggle_current_favorite(&mut self) {
+        if !self.state.favorites_available() {
+            return;
+        }
+        let Some(candidate) = self.current_favorite_candidate() else {
+            return;
+        };
+        let title = candidate.title.clone();
+        let now_favorited = self.state.favorites.toggle(candidate);
+
+        if self.state.favorites_focus && !now_favorited {
+            let remaining = self.state.favorites_landing_items().len();
+            if remaining == 0 {
+                self.state.favorites_focus = false;
+                self.state.favorites_landing_state.select(None);
+            } else {
+                let selected = self
+                    .state
+                    .favorites_landing_state
+                    .selected()
+                    .unwrap_or(0)
+                    .min(remaining - 1);
+                self.state.favorites_landing_state.select(Some(selected));
+            }
+        }
+
+        if self
+            .state
+            .search_query
+            .trim()
+            .eq_ignore_ascii_case("/favorites")
+        {
+            self.load_favorites_virtual_list();
+        }
+
+        self.state.notify(
+            if now_favorited {
+                NotificationKind::Success
+            } else {
+                NotificationKind::Info
+            },
+            "Favorites",
+            if now_favorited {
+                format!("Added \"{title}\" to Favorites.")
+            } else {
+                format!("Removed \"{title}\" from Favorites.")
+            },
+        );
+    }
+
+    fn open_favorite(&mut self, index: usize) {
+        let Some(item) = self
+            .state
+            .favorites_landing_items()
+            .get(index)
+            .map(|item| (*item).clone())
+        else {
+            return;
+        };
+        let subject_id = item.subject_id.clone();
+        let title = item.title.clone();
+
+        self.state.active_screen = Screen::Details;
+        self.state.active_subject_id = Some(subject_id.clone());
+        self.state.selected_details = Some(serde_json::json!({
+            "id": subject_id.clone(),
+            "subjectId": subject_id.clone(),
+            "title": item.title,
+            "subjectType": item.stype,
+            "releaseDate": item.release_year,
+            "cover": { "url": item.cover_url },
+        }));
+        self.state.selected_resources = None;
+        self.state.is_loading = true;
+        self.state.is_fetching_streams = false;
+        self.state.stream_error = None;
+        self.state.resource_list_state.select(None);
+        self.state.language_list_state.select(Some(0));
+        self.state.season_list_state.select(Some(0));
+        self.state.episode_list_state.select(Some(0));
+        self.state.language_chosen = false;
+        self.state.available_seasons.clear();
+        if let Some(cached) = self
+            .state
+            .image_cache
+            .get(&subject_id)
+            .or_else(|| self.state.search_posters.get(&subject_id))
+        {
+            self.state.poster_image = Some((**cached).clone());
+        } else {
+            self.state.poster_image = None;
+        }
+        self.state
+            .set_status(format!("Loading details for {title}..."), 150);
+
+        self.action_sender
+            .send(Action::FetchDetails(subject_id, false))
+            .ok();
+    }
+
+    pub(super) fn load_favorites_virtual_list(&mut self) {
+        self.state.input_mode = InputMode::Normal;
+        self.state.is_loading = false;
+        self.state.is_homepage_mode = false;
+        self.state.active_browse_preset = None;
+        self.state.browse_metrics.clear();
+        self.state.active_screen = Screen::Home;
+        self.state.active_subject_id = None;
+        self.state.active_preview_request = self.state.active_preview_request.wrapping_add(1);
+        self.state.search_results.clear();
+        self.state.search_error = None;
+        self.state.search_preview = None;
+        self.state.preview_loading = false;
+        self.state.poster_image = None;
+        self.state.poster_protocol = None;
+        self.state.failed_posters.clear();
+        self.state.in_flight_posters.clear();
+        self.state.search_list_state.select(None);
+        self.state.search_suggestions.clear();
+        self.state.suggest_index = None;
+        self.state.favorites_focus = false;
+
+        self.state.search_query = "/favorites".to_string();
+        let mut items = self.state.favorites.items.clone();
+        if items.is_empty() {
+            self.state.notify(
+                NotificationKind::Info,
+                "Favorites",
+                "No favorites yet. Star a title with * to add one.",
+            );
+        } else {
+            items.sort_by_key(|item| std::cmp::Reverse(item.added_at));
+
+            for item in items {
+                let provider = ProviderKind::parse(&item.provider).unwrap_or_else(|| {
+                    log::warn!(
+                        "unknown favorites provider '{}'; defaulting to MovieBox",
+                        item.provider
+                    );
+                    ProviderKind::MovieBox
+                });
+                self.state.search_results.push(SearchResult {
+                    id: item.subject_id.clone(),
+                    title: item.title.clone(),
+                    stype: item.stype,
+                    release_year: item.release_year.clone(),
+                    cover_url: item.cover_url.clone(),
+                    season: 0,
+                    episode: 0,
+                    provider,
+                });
+            }
+
+            self.state.search_list_state.select(Some(0));
+            self.prefetch_visible_posters();
+        }
+    }
+}

--- a/src/tui/app/keyboard.rs
+++ b/src/tui/app/keyboard.rs
@@ -559,11 +559,16 @@ impl App {
                                 }
                             }
                         }
+                        KeyCode::Char('*') if self.state.favorites_available() => {
+                            self.action_sender.send(Action::ToggleFavorite).ok();
+                        }
                         KeyCode::Char(c)
                             if (key.modifiers.is_empty()
                                 || key.modifiers == KeyModifiers::SHIFT) =>
                         {
                             self.state.input_mode = InputMode::Editing;
+                            self.state.favorites_focus = false;
+                            self.state.favorites_landing_state.select(None);
                             if c == '/' {
                                 self.state.search_query.clear();
                             }
@@ -638,6 +643,16 @@ impl App {
                     }
                     KeyCode::Char('b') => {
                         self.action_sender.send(Action::GoBack).ok();
+                    }
+                    KeyCode::Char('f') | KeyCode::Char('F') => {
+                        if !self.state.subtitle_popup
+                            && !self.state.player_picker_popup
+                            && !self.state.show_season_download_confirm
+                            && !self.state.show_episode_download_confirm
+                            && self.state.favorites_available()
+                        {
+                            self.action_sender.send(Action::ToggleFavorite).ok();
+                        }
                     }
 
                     KeyCode::Up => {

--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -5,6 +5,7 @@ use crate::tui::{action::Action, state::AppState, theme::Theme};
 
 mod addons;
 mod download;
+mod favorites;
 mod keyboard;
 mod mouse;
 mod navigation;

--- a/src/tui/app/mouse.rs
+++ b/src/tui/app/mouse.rs
@@ -295,18 +295,24 @@ impl App {
                     Constraint::Length(1),
                     Constraint::Length(3),
                     Constraint::Length(1),
+                    Constraint::Length(1),
                     Constraint::Min(0),
                     Constraint::Length(1),
                     Constraint::Length(1),
                 ])
                 .split(area);
 
-            if row == vertical_chunks[6].y {
+            if row == vertical_chunks[7].y {
                 self.handle_home_mode_click(col, area.width);
                 return None;
             }
-            if row == vertical_chunks[7].y {
+            if row == vertical_chunks[8].y {
                 self.handle_home_util_click(col, area.width);
+                return None;
+            }
+            if self.state.favorites_landing_visible()
+                && self.handle_favorites_landing_click(col, row, vertical_chunks[6])
+            {
                 return None;
             }
 
@@ -357,6 +363,8 @@ impl App {
 
         if row >= search_bar_area.y && row < search_bar_area.y + search_bar_area.height {
             self.state.input_mode = InputMode::Editing;
+            self.state.favorites_focus = false;
+            self.state.favorites_landing_state.select(None);
             return None;
         }
 
@@ -395,6 +403,54 @@ impl App {
         }
 
         None
+    }
+
+    /// Mirrors the layout math in `screens::home::render_favorites_landing`
+    /// so hitboxes stay in sync with what's drawn. Returns `true` if the
+    /// click landed inside the favorites card (handled either way).
+    fn handle_favorites_landing_click(&mut self, col: u16, row: u16, area: Rect) -> bool {
+        let row_count = self.state.favorites_landing_items().len() as u16;
+        if row_count == 0 || area.height < 2 || area.width < 20 {
+            return false;
+        }
+        let overflow = self
+            .state
+            .favorites
+            .items
+            .len()
+            .saturating_sub(row_count as usize);
+        let overflow_row = u16::from(overflow > 0);
+        let card_width = area.width.clamp(20, 56);
+        let content_height = (1 + row_count + overflow_row).min(area.height);
+        let card = Rect {
+            x: area.x + area.width.saturating_sub(card_width) / 2,
+            y: area.y,
+            width: card_width,
+            height: content_height,
+        };
+        if !card.contains(ratatui::layout::Position::new(col, row)) {
+            return false;
+        }
+
+        let rel_row = row - card.y;
+        if rel_row == 0 {
+            // Header row; no action.
+        } else if rel_row <= row_count {
+            let idx = (rel_row - 1) as usize;
+            let prev_selected = if self.state.favorites_focus {
+                self.state.favorites_landing_state.selected()
+            } else {
+                None
+            };
+            self.state.favorites_focus = true;
+            self.state.favorites_landing_state.select(Some(idx));
+            if prev_selected == Some(idx) {
+                self.action_sender.send(Action::OpenFavorite(idx)).ok();
+            }
+        } else if overflow > 0 && rel_row == row_count + 1 {
+            self.action_sender.send(Action::ShowFavorites).ok();
+        }
+        true
     }
 
     fn handle_home_mode_click(&mut self, col: u16, width: u16) {

--- a/src/tui/app/navigation.rs
+++ b/src/tui/app/navigation.rs
@@ -405,6 +405,11 @@ impl App {
                     self.state.browse_list_state.select(None);
                     return None;
                 }
+                if self.state.favorites_focus {
+                    self.state.favorites_focus = false;
+                    self.state.favorites_landing_state.select(None);
+                    return None;
+                }
                 match self.state.active_screen {
                     Screen::Home => {
                         self.state.is_loading = false;
@@ -513,6 +518,14 @@ impl App {
                 }
                 match self.state.active_screen {
                     Screen::Home => {
+                        if self.state.favorites_focus {
+                            let current =
+                                self.state.favorites_landing_state.selected().unwrap_or(0);
+                            if current > 0 {
+                                self.state.favorites_landing_state.select(Some(current - 1));
+                            }
+                            return None;
+                        }
                         let current = self.state.search_list_state.selected().unwrap_or(0);
                         if current > 0 {
                             self.state.search_list_state.select(Some(current - 1));
@@ -587,6 +600,23 @@ impl App {
                 }
                 match self.state.active_screen {
                     Screen::Home => {
+                        if self.state.favorites_focus {
+                            let total = self.state.favorites_landing_items().len();
+                            let current =
+                                self.state.favorites_landing_state.selected().unwrap_or(0);
+                            if current + 1 < total {
+                                self.state.favorites_landing_state.select(Some(current + 1));
+                            }
+                            return None;
+                        }
+                        if self.state.search_results.is_empty()
+                            && self.state.search_query.trim().is_empty()
+                            && self.state.favorites_landing_visible()
+                        {
+                            self.state.favorites_focus = true;
+                            self.state.favorites_landing_state.select(Some(0));
+                            return None;
+                        }
                         let current = self.state.search_list_state.selected().unwrap_or(0);
                         if current + 1 < self.state.search_results.len() {
                             self.state.search_list_state.select(Some(current + 1));
@@ -765,6 +795,12 @@ impl App {
                     self.action_sender
                         .send(Action::DownloadStream(sub_url_final))
                         .ok();
+                    return None;
+                }
+                if self.state.favorites_focus {
+                    if let Some(idx) = self.state.favorites_landing_state.selected() {
+                        self.action_sender.send(Action::OpenFavorite(idx)).ok();
+                    }
                     return None;
                 }
                 if self.state.active_screen == Screen::Home {

--- a/src/tui/app/requests.rs
+++ b/src/tui/app/requests.rs
@@ -204,6 +204,11 @@ impl App {
                     return None;
                 }
 
+                if lower_query == "/favorites" && self.state.favorites_available() {
+                    self.load_favorites_virtual_list();
+                    return None;
+                }
+
                 if self.handle_search_command(&query, &lower_query).is_some() {
                     return None;
                 }

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -234,6 +234,10 @@ impl App {
                 self.handle_playback(action).await;
             }
 
+            Action::ToggleFavorite | Action::ShowFavorites | Action::OpenFavorite(..) => {
+                self.handle_favorites(action).await;
+            }
+
             Action::DownloadStream(..)
             | Action::StartDownload(..)
             | Action::PromptDownloadEpisode

--- a/src/tui/app/search.rs
+++ b/src/tui/app/search.rs
@@ -205,6 +205,20 @@ impl App {
                     None
                 }
             }
+            crate::tui::commands::ParsedCommand::Favorites => {
+                if current_mode == crate::tui::state::AppMode::Tv {
+                    self.state.search_query.clear();
+                    self.state.input_mode = InputMode::Normal;
+                    self.state.notify(
+                        NotificationKind::Info,
+                        "TV Mode",
+                        format!("Command /favorites is available in Streaming Mode ({ctrl_s}) or Addon Mode ({ctrl_a})."),
+                    );
+                    Some(true)
+                } else {
+                    None
+                }
+            }
             crate::tui::commands::ParsedCommand::List => {
                 if current_mode == crate::tui::state::AppMode::Tv {
                     self.apply_tv_search_results(query, lower_query);

--- a/src/tui/commands.rs
+++ b/src/tui/commands.rs
@@ -4,6 +4,7 @@ use crate::tui::state::AppState;
 pub enum SlashCommand {
     Browse,
     History,
+    Favorites,
     List,
     Config,
     DownloadDir,
@@ -26,6 +27,7 @@ pub enum SlashCommand {
 pub enum ParsedCommand<'a> {
     Browse,
     History,
+    Favorites,
     List,
     Config,
     DownloadDir(&'a str),
@@ -45,9 +47,10 @@ pub enum ParsedCommand<'a> {
 }
 
 impl SlashCommand {
-    pub const ALL: [Self; 18] = [
+    pub const ALL: [Self; 19] = [
         Self::Browse,
         Self::History,
+        Self::Favorites,
         Self::List,
         Self::Config,
         Self::DownloadDir,
@@ -70,6 +73,7 @@ impl SlashCommand {
         match self {
             Self::Browse => "/browse",
             Self::History => "/history",
+            Self::Favorites => "/favorites",
             Self::List => "/list",
             Self::Config => "/config",
             Self::DownloadDir => "/download-dir",
@@ -93,6 +97,7 @@ impl SlashCommand {
         match self {
             Self::Browse => "Curated, rated & most-watched views",
             Self::History => "Watch history",
+            Self::Favorites => "Starred titles",
             Self::List => "Show all TV channels",
             Self::Config => {
                 if state.is_addon_mode {
@@ -128,6 +133,7 @@ impl SlashCommand {
                 (state.streaming_enabled && !state.is_tv_mode && !state.is_addon_mode)
                     || (state.addons_enabled && state.is_addon_mode)
             }
+            Self::Favorites => state.favorites_available(),
             Self::List => state.tv_enabled && state.is_tv_mode,
             Self::Config => {
                 (state.tv_enabled && state.is_tv_mode)
@@ -220,6 +226,7 @@ impl SlashCommand {
         match command_name.to_ascii_lowercase().as_str() {
             "/browse" => Some(ParsedCommand::Browse),
             "/history" => Some(ParsedCommand::History),
+            "/favorites" => Some(ParsedCommand::Favorites),
             "/list" => Some(ParsedCommand::List),
             "/config" => Some(ParsedCommand::Config),
             "/download-dir" => Some(ParsedCommand::DownloadDir(arg)),
@@ -307,6 +314,26 @@ mod tests {
         state.is_tv_mode = true;
         let tv_sug = SlashCommand::suggest(&state, "/download-dir");
         assert!(tv_sug.contains(&"/download-dir reset".to_string()));
+    }
+
+    #[test]
+    fn test_favorites_command_parses_and_is_available_by_default() {
+        let state = AppState::default();
+        assert_eq!(
+            SlashCommand::parse("/favorites"),
+            Some(ParsedCommand::Favorites)
+        );
+        assert!(SlashCommand::Favorites.is_available(&state));
+        assert_eq!(SlashCommand::Favorites.name(), "/favorites");
+    }
+
+    #[test]
+    fn test_favorites_command_unavailable_in_tv_mode() {
+        let state = AppState {
+            is_tv_mode: true,
+            ..Default::default()
+        };
+        assert!(!SlashCommand::Favorites.is_available(&state));
     }
 
     #[test]

--- a/src/tui/screens/details.rs
+++ b/src/tui/screens/details.rs
@@ -351,15 +351,34 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
     }
 
     let display_title = title.to_string();
+    let details_subject_id = state.active_subject_id.as_deref().unwrap_or("");
+    let is_favorited = state
+        .favorites
+        .is_favorite(&crate::models::SubjectIdentity {
+            provider: subject_provider(state, details_subject_id).cache_key(),
+            subject_id: details_subject_id,
+            title: &title,
+            stype: type_val,
+            release_year: year,
+        });
 
-    let title_line = Line::from(vec![
-        Span::styled(
-            display_title,
-            theme.text.add_modifier(ratatui::style::Modifier::BOLD),
-        ),
-        Span::styled("   ", theme.text),
-        Span::styled(format!("★ IMDb {}", imdb_rating), theme.rating),
-    ]);
+    let mut title_spans = Vec::new();
+    if is_favorited {
+        title_spans.push(Span::styled(
+            if state.basic_terminal { "* " } else { "★ " },
+            theme.rating,
+        ));
+    }
+    title_spans.push(Span::styled(
+        display_title,
+        theme.text.add_modifier(ratatui::style::Modifier::BOLD),
+    ));
+    title_spans.push(Span::styled("   ", theme.text));
+    title_spans.push(Span::styled(
+        format!("★ IMDb {}", imdb_rating),
+        theme.rating,
+    ));
+    let title_line = Line::from(title_spans);
 
     let duration_str = if duration.is_empty() || duration == "N/A" {
         "".to_string()
@@ -399,6 +418,16 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
                 metadata.push("[✓ Watched]".to_string());
             }
         }
+    }
+    if state.favorites_available() {
+        metadata.push(
+            if is_favorited {
+                "[f] Unfavorite"
+            } else {
+                "[f] Favorite"
+            }
+            .to_string(),
+        );
     }
     metadata.retain(|s| !s.trim().is_empty());
     let meta_line = Line::from(vec![Span::styled(

--- a/src/tui/screens/help.rs
+++ b/src/tui/screens/help.rs
@@ -116,6 +116,18 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
             Span::styled("Download Video Stream", theme.text),
         ]));
         help_text.push(Line::from(vec![
+            Span::styled("    [*]            ", theme.header),
+            Span::styled("Favorite / Unfavorite (Home)", theme.text),
+        ]));
+        help_text.push(Line::from(vec![
+            Span::styled("    [f]            ", theme.header),
+            Span::styled("Favorite / Unfavorite (Details)", theme.text),
+        ]));
+        help_text.push(Line::from(vec![
+            Span::styled("    /favorites     ", theme.header),
+            Span::styled("Favorited Titles", theme.text),
+        ]));
+        help_text.push(Line::from(vec![
             Span::styled("    /browse        ", theme.header),
             Span::styled("Browse Addon Catalogs", theme.text),
         ]));
@@ -156,12 +168,24 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
             Span::styled("Download Episode / Season Batch", theme.text),
         ]));
         help_text.push(Line::from(vec![
+            Span::styled("    [*]            ", theme.header),
+            Span::styled("Favorite / Unfavorite (Home)", theme.text),
+        ]));
+        help_text.push(Line::from(vec![
+            Span::styled("    [f]            ", theme.header),
+            Span::styled("Favorite / Unfavorite (Details)", theme.text),
+        ]));
+        help_text.push(Line::from(vec![
             Span::styled("    /browse        ", theme.header),
             Span::styled("Browse Movies & Series Categories", theme.text),
         ]));
         help_text.push(Line::from(vec![
             Span::styled("    /history       ", theme.header),
             Span::styled("Watch History", theme.text),
+        ]));
+        help_text.push(Line::from(vec![
+            Span::styled("    /favorites     ", theme.header),
+            Span::styled("Favorited Titles", theme.text),
         ]));
         help_text.push(Line::from(vec![
             Span::styled("    [r]            ", theme.header),

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -278,7 +278,7 @@ fn render_favorites_landing(frame: &mut Frame, area: Rect, state: &AppState, the
     if overflow > 0 {
         if let Some(row_area) = sections.last() {
             frame.render_widget(
-                Paragraph::new(format!("+{overflow} more \u{2014} /favorites"))
+                Paragraph::new(format!("+{overflow} more • /favorites"))
                     .style(theme.text_dim)
                     .alignment(Alignment::Center),
                 *row_area,

--- a/src/tui/screens/home.rs
+++ b/src/tui/screens/home.rs
@@ -192,6 +192,101 @@ fn render_search_state(
     frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), rows[1]);
 }
 
+fn render_favorites_landing(frame: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
+    if area.height < 2 || area.width < 20 {
+        return;
+    }
+
+    let items: Vec<crate::favorites::FavoriteItem> = state
+        .favorites_landing_items()
+        .into_iter()
+        .cloned()
+        .collect();
+    if items.is_empty() {
+        return;
+    }
+
+    let overflow = state.favorites.items.len().saturating_sub(items.len());
+    let card_width = area.width.clamp(20, 56);
+    let row_count = items.len() as u16;
+    let overflow_row = u16::from(overflow > 0);
+    let content_height = (1 + row_count + overflow_row).min(area.height);
+
+    let card = Rect {
+        x: area.x + area.width.saturating_sub(card_width) / 2,
+        y: area.y,
+        width: card_width,
+        height: content_height,
+    };
+
+    let mut constraints = vec![Constraint::Length(1)];
+    constraints.extend(std::iter::repeat_n(Constraint::Length(1), items.len()));
+    if overflow > 0 {
+        constraints.push(Constraint::Length(1));
+    }
+    let sections = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(card);
+
+    let header_style = if state.favorites_focus {
+        theme.title
+    } else {
+        theme.subtext1
+    };
+    frame.render_widget(
+        Paragraph::new("Favorites")
+            .style(header_style)
+            .alignment(Alignment::Center),
+        sections[0],
+    );
+
+    let selected = if state.favorites_focus {
+        state.favorites_landing_state.selected()
+    } else {
+        None
+    };
+
+    for (i, item) in items.iter().enumerate() {
+        let Some(row_area) = sections.get(1 + i) else {
+            break;
+        };
+        let is_selected = selected == Some(i);
+        let type_tag = if item.stype == 2 { "Series" } else { "Movie" };
+        let prefix = if is_selected {
+            if state.basic_terminal { "> " } else { "▌ " }
+        } else {
+            "  "
+        };
+        let title_style = if is_selected {
+            theme.title.add_modifier(Modifier::BOLD)
+        } else {
+            theme.text
+        };
+        let max_title_width = row_area.width.saturating_sub(14) as usize;
+        let line = Line::from(vec![
+            Span::styled(prefix, theme.accent),
+            Span::styled(
+                crate::tui::text::truncate_width(&item.title, max_title_width),
+                title_style,
+            ),
+            Span::styled(format!("  {type_tag}"), theme.text_dim),
+        ]);
+        frame.render_widget(Paragraph::new(line), *row_area);
+    }
+
+    if overflow > 0 {
+        if let Some(row_area) = sections.last() {
+            frame.render_widget(
+                Paragraph::new(format!("+{overflow} more \u{2014} /favorites"))
+                    .style(theme.text_dim)
+                    .alignment(Alignment::Center),
+                *row_area,
+            );
+        }
+    }
+}
+
 fn search_content(
     state: &AppState,
     view: SearchViewState,
@@ -329,6 +424,7 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
                 Constraint::Length(1),
                 Constraint::Length(3),
                 Constraint::Length(1),
+                Constraint::Length(1),
                 Constraint::Min(0),
                 Constraint::Length(1),
                 Constraint::Length(1),
@@ -377,6 +473,10 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
                 show_cursor,
                 true,
             );
+        }
+
+        if state.favorites_landing_visible() {
+            render_favorites_landing(frame, vertical_chunks[6], state, theme);
         }
 
         let ctrl_s = crate::tui::text::ctrl_key("S");
@@ -452,7 +552,7 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
 
         frame.render_widget(
             Paragraph::new(Line::from(mode_spans)).alignment(Alignment::Center),
-            vertical_chunks[6],
+            vertical_chunks[7],
         );
 
         let util_spans = vec![
@@ -469,7 +569,7 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
 
         frame.render_widget(
             Paragraph::new(Line::from(util_spans)).alignment(Alignment::Center),
-            vertical_chunks[7],
+            vertical_chunks[8],
         );
     } else {
         if state.is_loading && state.search_results.is_empty() {
@@ -671,7 +771,20 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
                     .split(text_area);
 
                 let title_style = if is_selected { theme.title } else { theme.text };
-                let max_title_width = text_area.width.saturating_sub(4) as usize;
+                // TV channels are never favoritable (see current_favorite_candidate), so
+                // this is always false for TV mode's channel list, keeping it byte-identical.
+                let is_favorited = res.stype != 3
+                    && state
+                        .favorites
+                        .is_favorite(&crate::models::SubjectIdentity {
+                            provider: res.provider.cache_key(),
+                            subject_id: &res.id,
+                            title: &res.title,
+                            stype: res.stype,
+                            release_year: &res.release_year,
+                        });
+                let title_reserved = if is_favorited { 6 } else { 4 };
+                let max_title_width = text_area.width.saturating_sub(title_reserved) as usize;
                 let display_title = crate::tui::text::truncate_width(&res.title, max_title_width);
 
                 let mut type_tag = if state.is_tv_mode || res.stype == 3 {
@@ -689,10 +802,15 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &mut AppState, theme: &Theme) 
                     type_tag = "Unknown".to_string();
                 }
 
-                let title_line = ratatui::text::Line::from(vec![
-                    ratatui::text::Span::raw(" "),
-                    ratatui::text::Span::styled(display_title, title_style),
-                ]);
+                let mut title_spans = vec![ratatui::text::Span::raw(" ")];
+                if is_favorited {
+                    title_spans.push(ratatui::text::Span::styled(
+                        if state.basic_terminal { "* " } else { "★ " },
+                        theme.rating,
+                    ));
+                }
+                title_spans.push(ratatui::text::Span::styled(display_title, title_style));
+                let title_line = ratatui::text::Line::from(title_spans);
                 if text_layout[1].height > 0 {
                     frame.render_widget(Paragraph::new(title_line), text_layout[1]);
                 }

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -182,6 +182,9 @@ pub struct AppState {
     pub addon_input_buffer: String,
     pub addon_input_cursor: usize,
     pub history: crate::history::HistoryManager,
+    pub favorites: crate::favorites::FavoritesManager,
+    pub favorites_focus: bool,
+    pub favorites_landing_state: ListState,
 }
 
 impl Default for AppState {
@@ -322,6 +325,9 @@ impl Default for AppState {
             addon_input_buffer: String::new(),
             addon_input_cursor: 0,
             history: crate::history::HistoryManager::new(),
+            favorites: crate::favorites::FavoritesManager::new(),
+            favorites_focus: false,
+            favorites_landing_state: ListState::default(),
         }
     }
 }
@@ -408,6 +414,8 @@ impl AppState {
         self.in_flight_posters.clear();
         self.search_list_state.select(None);
         self.is_homepage_mode = false;
+        self.favorites_focus = false;
+        self.favorites_landing_state.select(None);
     }
 
     pub fn clear_details_state(&mut self) {
@@ -424,6 +432,27 @@ impl AppState {
         self.resource_list_state.select(None);
         self.language_list_state.select(None);
         self.details_pane = DetailsPane::Streams;
+    }
+
+    /// Same availability predicate `/history` and `/browse` already use:
+    /// Streaming and Addon modes only.
+    pub fn favorites_available(&self) -> bool {
+        (self.streaming_enabled && !self.is_tv_mode && !self.is_addon_mode)
+            || (self.addons_enabled && self.is_addon_mode)
+    }
+
+    pub fn favorites_landing_visible(&self) -> bool {
+        self.favorites_available() && !self.favorites.items.is_empty()
+    }
+
+    /// Up to 5 most-recently-favorited titles, newest first. This is the
+    /// fixed set the landing row navigates over; the rest are reachable via
+    /// `/favorites`.
+    pub fn favorites_landing_items(&self) -> Vec<&crate::favorites::FavoriteItem> {
+        let mut items: Vec<&crate::favorites::FavoriteItem> = self.favorites.items.iter().collect();
+        items.sort_by_key(|item| std::cmp::Reverse(item.added_at));
+        items.truncate(5);
+        items
     }
 
     pub fn loading_dots(&self) -> &'static str {

--- a/tests/favorites_lifecycle.rs
+++ b/tests/favorites_lifecycle.rs
@@ -1,0 +1,209 @@
+use moviebox_tui::favorites::FavoriteItem;
+use moviebox_tui::providers::models::ProviderKind;
+use moviebox_tui::tui::action::Action;
+use moviebox_tui::tui::app::App;
+use moviebox_tui::tui::state::Screen;
+
+#[allow(clippy::too_many_arguments)]
+fn dummy_favorite(
+    provider: &str,
+    subject_id: &str,
+    title: &str,
+    stype: i64,
+    release_year: &str,
+    added_at: u64,
+) -> FavoriteItem {
+    FavoriteItem {
+        provider: provider.to_string(),
+        subject_id: subject_id.to_string(),
+        title: title.to_string(),
+        cover_url: Some(format!("https://img.example.com/{subject_id}.jpg")),
+        stype,
+        release_year: release_year.to_string(),
+        added_at,
+    }
+}
+
+#[test]
+fn test_favorites_path_is_outside_clear_cache_scope() {
+    // /clear-cache (crate::cache::clear_all_cache) only removes cache_dir()
+    // and data_dir()/iptv_cache. favorites.json must live outside both.
+    let favorites_path = moviebox_tui::config::favorites_path().expect("favorites path");
+    let cache_dir = moviebox_tui::config::cache_dir();
+    let data_dir = moviebox_tui::config::data_dir().expect("data dir");
+    let iptv_cache = data_dir.join("iptv_cache");
+
+    assert!(!favorites_path.starts_with(&cache_dir));
+    assert_ne!(favorites_path.parent().unwrap(), iptv_cache);
+    assert!(favorites_path.starts_with(&data_dir));
+}
+
+#[test]
+fn test_clearing_watch_history_leaves_favorites_intact() {
+    let mut app = App::new();
+    app.state_mut().favorites.clear();
+    app.state_mut()
+        .favorites
+        .items
+        .push(dummy_favorite("moviebox", "mb_1", "Dune", 1, "2021", 1000));
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "moviebox", "mb_2", "Arrival", 1, "2016", 2000,
+    ));
+
+    app.state_mut().history.clear();
+
+    assert_eq!(app.state().favorites.items.len(), 2);
+
+    app.state_mut().favorites.clear();
+}
+
+#[tokio::test]
+async fn test_favorites_slash_command_populates_search_results_accurately() {
+    let mut app = App::new();
+    app.state_mut().favorites.clear();
+
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "moviebox",
+        "mb_101",
+        "Gladiator",
+        1,
+        "2000",
+        1000,
+    ));
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "addons",
+        "tt0111161",
+        "The Shawshank Redemption",
+        1,
+        "1994",
+        2000,
+    ));
+
+    app.state_mut().active_screen = Screen::Home;
+    app.handle_action(Action::Search {
+        query: "/favorites".to_string(),
+        force_refresh: false,
+    })
+    .await;
+
+    assert_eq!(app.state().search_query, "/favorites");
+    assert_eq!(app.state().search_results.len(), 2);
+
+    let titles: Vec<_> = app
+        .state()
+        .search_results
+        .iter()
+        .map(|r| r.title.as_str())
+        .collect();
+    assert!(titles.contains(&"Gladiator"));
+    assert!(titles.contains(&"The Shawshank Redemption"));
+
+    let providers: Vec<_> = app
+        .state()
+        .search_results
+        .iter()
+        .map(|r| r.provider)
+        .collect();
+    assert!(providers.contains(&ProviderKind::MovieBox));
+    assert!(providers.contains(&ProviderKind::Addons));
+
+    app.state_mut().favorites.clear();
+}
+
+#[tokio::test]
+async fn test_favorites_virtual_list_orders_newest_first() {
+    let mut app = App::new();
+    app.state_mut().favorites.clear();
+
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "moviebox",
+        "mb_old",
+        "Oldest Pick",
+        1,
+        "2001",
+        100,
+    ));
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "moviebox",
+        "mb_new",
+        "Newest Pick",
+        1,
+        "2020",
+        3000,
+    ));
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "moviebox",
+        "mb_mid",
+        "Middle Pick",
+        1,
+        "2010",
+        2000,
+    ));
+
+    app.state_mut().active_screen = Screen::Home;
+    app.handle_action(Action::Search {
+        query: "/favorites".to_string(),
+        force_refresh: false,
+    })
+    .await;
+
+    let titles: Vec<_> = app
+        .state()
+        .search_results
+        .iter()
+        .map(|r| r.title.clone())
+        .collect();
+    assert_eq!(
+        titles,
+        vec![
+            "Newest Pick".to_string(),
+            "Middle Pick".to_string(),
+            "Oldest Pick".to_string(),
+        ]
+    );
+
+    app.state_mut().favorites.clear();
+}
+
+#[tokio::test]
+async fn test_toggle_favorite_action_on_home_selected_result() {
+    let mut app = App::new();
+    app.state_mut().favorites.clear();
+
+    app.state_mut().active_screen = Screen::Home;
+    app.state_mut().search_results = vec![moviebox_tui::tui::state::SearchResult {
+        id: "mb_toggle".to_string(),
+        title: "Interstellar".to_string(),
+        stype: 1,
+        release_year: "2014".to_string(),
+        cover_url: None,
+        season: 0,
+        episode: 0,
+        provider: ProviderKind::MovieBox,
+    }];
+    app.state_mut().search_list_state.select(Some(0));
+
+    app.handle_action(Action::ToggleFavorite).await;
+    assert_eq!(app.state().favorites.items.len(), 1);
+    assert_eq!(app.state().favorites.items[0].subject_id, "mb_toggle");
+
+    app.handle_action(Action::ToggleFavorite).await;
+    assert!(app.state().favorites.items.is_empty());
+}
+
+#[tokio::test]
+async fn test_open_favorite_navigates_to_details_screen() {
+    let mut app = App::new();
+    app.state_mut().favorites.clear();
+    app.state_mut().favorites.items.push(dummy_favorite(
+        "moviebox", "mb_open", "Arrival", 1, "2016", 5000,
+    ));
+
+    app.state_mut().active_screen = Screen::Home;
+    app.handle_action(Action::OpenFavorite(0)).await;
+
+    assert_eq!(app.state().active_screen, Screen::Details);
+    assert_eq!(app.state().active_subject_id.as_deref(), Some("mb_open"));
+
+    app.state_mut().favorites.clear();
+}


### PR DESCRIPTION
## What does this PR do?

Adds a Favorites feature — star whole movies and series and reach them instantly from the landing screen. Closes #88.

- Star a title with `*` on the Home screen, or `f`/`F` on the Details screen (with a `★` indicator and a `[f] Favorite`/`[f] Unfavorite` hint)
- Arrow-navigable Favorites row on the landing screen (Streaming and Addon modes), showing up to 5 recently-starred titles with a `+N more — /favorites` overflow link. `Down` from the search bar focuses the row, `Enter` opens the selected title, `Esc` releases focus. Mouse clicks work the same way.
- `/favorites` slash command mirrors `/history`, loading the full starred list into the results view; `*` unstars a row there
- New `favorites.json`, independent of `history.json` and untouched by `/clear-cache`. No cap on favorite count.
- Scoped to whole titles only — no individual episodes, no TV channels
- Extracted cross-provider title-identity matching into `SubjectIdentity` (`src/models.rs`), now shared by watch history and favorites so remakes, cross-provider duplicates, and movie/series title collisions dedupe identically. `HistoryManager::is_same_show` now delegates to it; all existing history tests pass unchanged.

## Screenshots

<img width="742" height="710" alt="Screenshot 2026-08-21 235554" src="https://github.com/user-attachments/assets/9ccc56b3-7636-427e-9812-720a371a4a37" />

<img width="748" height="823" alt="Screenshot 2026-08-21 235643" src="https://github.com/user-attachments/assets/82ddd7b8-366e-493f-8aa4-c854e3fd38e1" />

<img width="994" height="733" alt="Screenshot 2026-08-21 235724" src="https://github.com/user-attachments/assets/3448bb50-e3e1-4bbd-863d-e558e3a64b6e" />

<img width="1002" height="338" alt="Screenshot 2026-08-21 235746" src="https://github.com/user-attachments/assets/ccc70ccf-1db6-4bdc-b72f-f52d8902637b" />

## Checklist

- [x] `cargo fmt --check` succeeds
- [x] `cargo clippy --all-targets --locked -- -D warnings` succeeds
- [x] `cargo check --locked` succeeds
- [x] Docs updated if this changes features, keybindings, or usage
- [x] No placeholder test step was added; also ran the full `cargo test --locked` suite (159 passing) since this repo does have one now

> Formatting and linting are enforced automatically by the pre-commit hook and CI.
