### PR TITLE
fix: replace active playback instead of blocking new requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- **Seamless Playback Handoff**: Starting new playback while a player is already active no longer shows "Playback already active — stop the current player before starting another"; it now replaces the running session instead. The previous title's watch progress is still reconciled and saved before the new one takes over. Playback still keeps running after quitting the TUI, unchanged.
+- **Seamless Playback Handoff**: Starting new playback while a player is already active no longer shows "Playback already active: stop the current player before starting another"; it now replaces the running session instead. The previous title's watch progress is still reconciled and saved before the new one takes over. Playback still keeps running after quitting the TUI, unchanged.
 
 ## [0.1.13] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+- **Seamless Playback Handoff**: Starting new playback while a player is already active no longer shows "Playback already active — stop the current player before starting another"; it now replaces the running session instead. The previous title's watch progress is still reconciled and saved before the new one takes over. Playback still keeps running after quitting the TUI, unchanged.
+
 ## [0.1.13] - 2026-08-21
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ semver = "1.0.28"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 thiserror = "2.0.18"
-tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "sync", "time", "fs", "io-util", "signal"] }
+tokio = { version = "1.52.3", features = ["rt-multi-thread", "macros", "sync", "time", "fs", "io-util", "signal", "process"] }
 url = "2.5.8"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.0"

--- a/docs/players.md
+++ b/docs/players.md
@@ -59,5 +59,21 @@ reconciled into `history.json`.
 ## Spawning
 
 `launch_player` spawns the player with null stdin/stdout, piped stderr, and its own
-process group (Unix) or no-console flag (Windows). A blocking task reads stderr and
-reports a crash if the process exits non-zero within a few seconds with output.
+process group (Unix) or no-console flag (Windows), using `tokio::process` so the
+watcher task can wait on it without blocking a thread. The watcher reads stderr
+concurrently and reports a crash if the process exits non-zero within a few seconds
+with output.
+
+## Replacing an active session
+
+Starting new playback while a player is already running does **not** require closing
+the old one first: `launch_player` bumps a `playback_generation` counter and signals
+the previous session's watcher (via a `oneshot` channel) to kill its player and hand
+off. The old session's watcher still reconciles watch history and saves progress
+before exiting, exactly as it would on a normal exit — only its `PlayerCrashed` /
+`PlayerExited` report is tagged with the now-superseded generation, so `handle_playback`
+ignores it instead of clobbering the flags for the session that's actually playing.
+
+A dropped-without-sending stop channel (e.g. the app quitting while playback is
+active) is deliberately **not** treated as a stop request, so playback keeps running
+after the TUI exits, matching the existing behavior.

--- a/docs/players.md
+++ b/docs/players.md
@@ -70,7 +70,7 @@ Starting new playback while a player is already running does **not** require clo
 the old one first: `launch_player` bumps a `playback_generation` counter and signals
 the previous session's watcher (via a `oneshot` channel) to kill its player and hand
 off. The old session's watcher still reconciles watch history and saves progress
-before exiting, exactly as it would on a normal exit — only its `PlayerCrashed` /
+before exiting, exactly as it would on a normal exit. Only its `PlayerCrashed` /
 `PlayerExited` report is tagged with the now-superseded generation, so `handle_playback`
 ignores it instead of clobbering the flags for the session that's actually playing.
 

--- a/src/tui/action.rs
+++ b/src/tui/action.rs
@@ -142,6 +142,6 @@ pub enum Action {
         completed: bool,
     },
     ReconcileHistory,
-    PlayerCrashed(Option<i32>, String),
-    PlayerExited,
+    PlayerCrashed(u64, Option<i32>, String),
+    PlayerExited(u64),
 }

--- a/src/tui/app/mouse.rs
+++ b/src/tui/app/mouse.rs
@@ -1,7 +1,6 @@
 use super::App;
 use crate::tui::{
     action::Action,
-    overlay::NotificationKind,
     state::{BrowsePreset, DetailsPane, InputMode, Screen},
 };
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
@@ -711,13 +710,7 @@ impl App {
                 self.state.resource_list_state.select(Some(target_idx));
 
                 if prev_selected == Some(target_idx) {
-                    if self.state.is_playing {
-                        self.state.notify(
-                            NotificationKind::Warning,
-                            "Playback already active",
-                            "Stop the current player before starting another.",
-                        );
-                    } else if !self.state.is_resolving_playback
+                    if !self.state.is_resolving_playback
                         && self.state.last_playback_launch.elapsed().as_millis() >= 500
                     {
                         self.action_sender.send(Action::PlayStream(false)).ok();

--- a/src/tui/app/playback.rs
+++ b/src/tui/app/playback.rs
@@ -122,6 +122,17 @@ impl App {
             return;
         }
 
+        // Replace whatever's currently playing instead of blocking on it: signal
+        // the previous session's watcher to kill its player and hand off cleanly
+        // (progress is still saved; see the `was_replaced` handling below).
+        if let Some(stop_tx) = self.state.playback_stop.take() {
+            let _ = stop_tx.send(());
+        }
+        self.state.playback_generation = self.state.playback_generation.wrapping_add(1);
+        let generation = self.state.playback_generation;
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+        self.state.playback_stop = Some(stop_tx);
+
         let history_item = self.build_watch_history_item();
         let resume_seconds = if let Some(item) = &history_item {
             self.state
@@ -200,7 +211,7 @@ impl App {
                 .as_ref()
                 .map(|(p, s, se, ep)| (p.as_str(), s.as_str(), *se, *ep));
 
-            let mut command = crate::tui::player::command(
+            let mut command: tokio::process::Command = crate::tui::player::command(
                 kind,
                 &link,
                 local_subtitle.as_deref(),
@@ -208,7 +219,8 @@ impl App {
                 window,
                 resume_seconds,
                 tracker_ref,
-            );
+            )
+            .into();
             command.stdin(std::process::Stdio::null());
             command.stdout(std::process::Stdio::null());
             command.stderr(std::process::Stdio::piped());
@@ -220,7 +232,6 @@ impl App {
             }
             #[cfg(windows)]
             {
-                use std::os::windows::process::CommandExt;
                 command.creation_flags(0x08000000);
             }
 
@@ -229,59 +240,94 @@ impl App {
                     let start_time = std::time::Instant::now();
                     let stderr_stream = child.stderr.take();
 
-                    tokio::task::spawn_blocking(move || {
+                    let stderr_task = tokio::spawn(async move {
                         let mut error_output = String::new();
                         if let Some(mut stderr) = stderr_stream {
-                            use std::io::Read;
-                            let _ = stderr.read_to_string(&mut error_output);
+                            use tokio::io::AsyncReadExt;
+                            let _ = stderr.read_to_string(&mut error_output).await;
                         }
+                        error_output
+                    });
 
-                        let result = child.wait();
-
-                        if let Ok(status) = result {
-                            let clean_error = error_output.trim().to_string();
-                            if !status.success()
-                                && start_time.elapsed().as_secs() < 3
-                                && !clean_error.is_empty()
-                            {
-                                sender
-                                    .send(Action::PlayerCrashed(status.code(), clean_error))
-                                    .ok();
-                            } else {
-                                sender.send(Action::ReconcileHistory).ok();
-
-                                if let Some(item) = history_item {
-                                    let elapsed = start_time.elapsed().as_secs();
-                                    if elapsed >= 30 {
-                                        let duration = item.duration_seconds;
-                                        let start_pos = resume_seconds.unwrap_or(0);
-                                        let total_pos = start_pos.saturating_add(elapsed);
-                                        let progress = if let Some(d) = duration {
-                                            total_pos.min(d)
-                                        } else {
-                                            total_pos
-                                        };
-                                        let completed = duration.is_some_and(|d| {
-                                            d > 0 && progress >= (d as f64 * 0.90) as u64
-                                        });
-                                        sender
-                                            .send(Action::UpdateProgress {
-                                                item,
-                                                progress,
-                                                duration,
-                                                completed,
-                                            })
-                                            .ok();
+                    // Wait for the child to exit on its own, unless a newer
+                    // playback request explicitly asks us to hand off. A
+                    // dropped-without-sending stop channel (e.g. the app
+                    // quitting) must NOT be treated as a stop request, since
+                    // playback is expected to keep running after the TUI
+                    // exits.
+                    let mut stop_rx = Some(stop_rx);
+                    let mut was_replaced = false;
+                    let wait_result = loop {
+                        match stop_rx.take() {
+                            Some(mut rx) => {
+                                tokio::select! {
+                                    status = child.wait() => break status,
+                                    signal = &mut rx => {
+                                        match signal {
+                                            Ok(()) => {
+                                                was_replaced = true;
+                                                let _ = child.kill().await;
+                                                break child.wait().await;
+                                            }
+                                            Err(_) => continue,
+                                        }
                                     }
                                 }
                             }
+                            None => break child.wait().await,
                         }
+                    };
 
-                        if let Some(path) = temporary_subtitle {
-                            let _ = std::fs::remove_file(path);
+                    let error_output = stderr_task.await.unwrap_or_default();
+
+                    if let Ok(status) = wait_result {
+                        let clean_error = error_output.trim().to_string();
+                        if !was_replaced
+                            && !status.success()
+                            && start_time.elapsed().as_secs() < 3
+                            && !clean_error.is_empty()
+                        {
+                            sender
+                                .send(Action::PlayerCrashed(
+                                    generation,
+                                    status.code(),
+                                    clean_error,
+                                ))
+                                .ok();
+                        } else {
+                            sender.send(Action::ReconcileHistory).ok();
+
+                            if let Some(item) = history_item {
+                                let elapsed = start_time.elapsed().as_secs();
+                                if elapsed >= 30 {
+                                    let duration = item.duration_seconds;
+                                    let start_pos = resume_seconds.unwrap_or(0);
+                                    let total_pos = start_pos.saturating_add(elapsed);
+                                    let progress = if let Some(d) = duration {
+                                        total_pos.min(d)
+                                    } else {
+                                        total_pos
+                                    };
+                                    let completed = duration.is_some_and(|d| {
+                                        d > 0 && progress >= (d as f64 * 0.90) as u64
+                                    });
+                                    sender
+                                        .send(Action::UpdateProgress {
+                                            item,
+                                            progress,
+                                            duration,
+                                            completed,
+                                        })
+                                        .ok();
+                                }
+                            }
                         }
-                        sender.send(Action::PlayerExited).ok();
-                    });
+                    }
+
+                    if let Some(path) = temporary_subtitle {
+                        let _ = tokio::fs::remove_file(path).await;
+                    }
+                    sender.send(Action::PlayerExited(generation)).ok();
                 }
                 Err(error) => {
                     log::error!(
@@ -294,11 +340,12 @@ impl App {
                     }
                     sender
                         .send(Action::PlayerCrashed(
+                            generation,
                             None,
                             format!("Failed to spawn player executable: {error}"),
                         ))
                         .ok();
-                    sender.send(Action::PlayerExited).ok();
+                    sender.send(Action::PlayerExited(generation)).ok();
                 }
             }
         });
@@ -309,14 +356,6 @@ impl App {
     pub(super) async fn handle_playback(&mut self, action: Action) -> Option<()> {
         match action {
             Action::PlayStream(open_with) => {
-                if self.state.is_playing {
-                    self.state.notify(
-                        NotificationKind::Warning,
-                        "Playback already active",
-                        "Stop the current player before starting another.",
-                    );
-                    return None;
-                }
                 if self.state.is_resolving_playback
                     || self.state.last_playback_launch.elapsed().as_millis() < 500
                 {
@@ -537,14 +576,6 @@ impl App {
                 }
             }
             Action::LaunchMpv(link, subtitle_url) => {
-                if self.state.is_playing {
-                    self.state.notify(
-                        NotificationKind::Warning,
-                        "Playback already active",
-                        "Stop the current player before starting another.",
-                    );
-                    return None;
-                }
                 if self.state.last_playback_launch.elapsed().as_millis() < 500 {
                     return None;
                 }
@@ -656,11 +687,22 @@ impl App {
             Action::ReconcileHistory => {
                 self.state.history.reconcile_pending_playback_states();
             }
-            Action::PlayerExited => {
-                self.state.is_playing = false;
-                self.state.is_resolving_playback = false;
+            Action::PlayerExited(generation) => {
+                // A superseded session (the user switched to a different
+                // title) exits after the new one already started; don't let
+                // its stale exit clear the flags for the session that's
+                // actually playing now.
+                if generation == self.state.playback_generation {
+                    self.state.is_playing = false;
+                    self.state.is_resolving_playback = false;
+                }
             }
-            Action::PlayerCrashed(code, error_msg) => {
+            Action::PlayerCrashed(generation, code, error_msg) => {
+                if generation != self.state.playback_generation {
+                    // A replaced session's forced-kill exit can look like a
+                    // crash; the user already moved on, so stay quiet.
+                    return None;
+                }
                 self.state.is_playing = false;
                 self.state.is_resolving_playback = false;
                 let code_str = code

--- a/src/tui/app/run.rs
+++ b/src/tui/app/run.rs
@@ -230,7 +230,7 @@ impl App {
             | Action::UpdateProgress { .. }
             | Action::ReconcileHistory
             | Action::PlayerCrashed(..)
-            | Action::PlayerExited => {
+            | Action::PlayerExited(..) => {
                 self.handle_playback(action).await;
             }
 

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -130,6 +130,8 @@ pub struct AppState {
     pub is_resolving_playback: bool,
     pub is_playing: bool,
     pub last_playback_launch: std::time::Instant,
+    pub playback_generation: u64,
+    pub playback_stop: Option<tokio::sync::oneshot::Sender<()>>,
     pub status_message: String,
     pub status_timer: usize,
     pub notifications: std::collections::VecDeque<crate::tui::overlay::Notification>,
@@ -275,6 +277,8 @@ impl Default for AppState {
             last_playback_launch: std::time::Instant::now()
                 .checked_sub(std::time::Duration::from_secs(5))
                 .unwrap_or_else(std::time::Instant::now),
+            playback_generation: 0,
+            playback_stop: None,
             status_message: String::new(),
             status_timer: 0,
             notifications: std::collections::VecDeque::new(),

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -130,18 +130,61 @@ async fn test_rapid_playback_invocations_debounced_and_single_flight() {
 }
 
 #[tokio::test]
-async fn test_active_player_session_blocks_duplicate_playback_and_recovers_on_exit() {
+async fn test_new_playback_request_replaces_active_session_instead_of_blocking() {
     let mut app = App::new();
     app.state_mut().is_playing = true;
+    let notifications_before = app.state().notifications.len();
 
+    // A new playback request while one is already active must no longer be
+    // refused with a "Playback already active" warning; it should be free to
+    // proceed and hand off from the old session.
     let res = app.handle_action(Action::PlayStream(false)).await;
     assert_eq!(res, None);
-    assert!(!app.state().notifications.is_empty());
-    let notif = app.state().notifications.back().unwrap();
-    assert_eq!(notif.kind, NotificationKind::Warning);
-    assert_eq!(notif.title, "Playback already active");
+    assert_eq!(app.state().notifications.len(), notifications_before);
+    assert!(
+        app.state()
+            .notifications
+            .iter()
+            .all(|n| n.title != "Playback already active")
+    );
+}
 
-    app.handle_action(Action::PlayerExited).await;
+#[tokio::test]
+async fn test_stale_player_exit_does_not_clobber_a_newer_playback_session() {
+    let mut app = App::new();
+
+    // Simulate a second launch having already bumped the generation past the
+    // exiting (replaced) session's generation.
+    app.state_mut().playback_generation = 5;
+    app.state_mut().is_playing = true;
+    app.state_mut().is_resolving_playback = true;
+
+    app.handle_action(Action::PlayerExited(3)).await;
+    assert!(app.state().is_playing, "stale exit must not stop playback");
+    assert!(app.state().is_resolving_playback);
+
+    app.handle_action(Action::PlayerExited(5)).await;
     assert!(!app.state().is_playing);
     assert!(!app.state().is_resolving_playback);
+}
+
+#[tokio::test]
+async fn test_stale_player_crash_is_suppressed_but_current_generation_crash_notifies() {
+    let mut app = App::new();
+    app.state_mut().playback_generation = 5;
+    app.state_mut().is_playing = true;
+    let notifications_before = app.state().notifications.len();
+
+    app.handle_action(Action::PlayerCrashed(3, Some(1), "stale error".to_string()))
+        .await;
+    assert!(app.state().is_playing, "stale crash must not stop playback");
+    assert_eq!(app.state().notifications.len(), notifications_before);
+
+    app.handle_action(Action::PlayerCrashed(5, Some(1), "real error".to_string()))
+        .await;
+    assert!(!app.state().is_playing);
+    assert_eq!(app.state().notifications.len(), notifications_before + 1);
+    let notif = app.state().notifications.back().unwrap();
+    assert_eq!(notif.kind, NotificationKind::Error);
+    assert_eq!(notif.title, "Player Error");
 }

--- a/tests/grand_user_journey.rs
+++ b/tests/grand_user_journey.rs
@@ -79,7 +79,8 @@ async fn test_grand_user_journey_complete_lifecycle() {
     assert!(duplicate_play);
 
     app.state_mut().is_playing = false;
-    app.handle_action(Action::PlayerExited).await;
+    app.handle_action(Action::PlayerExited(app.state().playback_generation))
+        .await;
 
     let history_item = moviebox_tui::history::WatchHistoryItem {
         provider: "moviebox".to_string(),


### PR DESCRIPTION
## What does this PR do?

Starting new playback while a player is already active no longer blocks with "Playback already active — stop the current player before starting another." It now replaces the running session instead, same as picking a new video in basically any other media app.

- `launch_player` bumps a `playback_generation` counter and signals the previous session's watcher (a `oneshot` channel) to kill its player and hand off. The old session still reconciles watch history and saves progress before exiting, exactly as a normal exit would — only its `PlayerCrashed`/`PlayerExited` report is tagged with the now-stale generation, so `handle_playback` ignores it instead of clobbering the flags for the session that's actually playing.
- A dropped-without-sending stop channel (e.g. the app quitting while playback is active) is deliberately *not* treated as a stop request, so playback keeps running after the TUI exits — same as today.
- Switched process spawning from `std::process` to `tokio::process` so the watcher can wait on the child asynchronously (`tokio::select!`) instead of blocking a dedicated thread, which is what makes the interruption possible without polling or shared mutable state.

## Checklist

- [x] `cargo fmt --check` succeeds
- [x] `cargo clippy --all-targets --locked -- -D warnings` succeeds
- [x] `cargo check --locked` succeeds
- [x] Docs updated if this changes features, keybindings, or usage
- [x] No placeholder test step was added; also ran the full `cargo test --locked` suite (142 passing)

> Formatting and linting are enforced automatically by the pre-commit hook and CI.
