### PR TITLE
Fix/playback audio subs and crash reporting

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -2,6 +2,15 @@ pub mod tracker;
 
 use std::{path::Path, process::Command};
 
+/// Preferred audio track languages, most preferred first. Falls back to the
+/// container's default track if none of these are present.
+const PREFERRED_AUDIO_LANGS: &str = "eng,en,english";
+
+/// Preferred embedded subtitle track languages, most preferred first. Only
+/// affects tracks muxed into the container; external subtitle files passed
+/// via `subtitle` are shown regardless of this preference.
+const PREFERRED_SUBTITLE_LANGS: &str = "eng,en,english";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PlayerKind {
     Mpv,
@@ -222,6 +231,9 @@ fn mpv_command(
         command.arg(format!("{opt}={subtitle}"));
     }
 
+    command.arg(format!("{prefix}alang={PREFERRED_AUDIO_LANGS}"));
+    command.arg(format!("{prefix}slang={PREFERRED_SUBTITLE_LANGS}"));
+
     command.arg(url);
 
     command
@@ -333,6 +345,9 @@ fn vlc_command(
     if let Some(subtitle) = subtitle {
         command.arg(format!("--sub-file={subtitle}"));
     }
+
+    command.arg(format!("--audio-language={PREFERRED_AUDIO_LANGS}"));
+    command.arg(format!("--sub-language={PREFERRED_SUBTITLE_LANGS}"));
 
     command.arg(url);
     command

--- a/src/tui/app/playback.rs
+++ b/src/tui/app/playback.rs
@@ -240,30 +240,47 @@ impl App {
 
                         if let Ok(status) = result {
                             let clean_error = error_output.trim().to_string();
-                            if !status.success()
-                                && start_time.elapsed().as_secs() < 3
-                                && !clean_error.is_empty()
-                            {
+                            if !status.success() {
+                                let message = if clean_error.is_empty() {
+                                    #[cfg(unix)]
+                                    {
+                                        use std::os::unix::process::ExitStatusExt;
+                                        match status.signal() {
+                                            Some(sig) => format!(
+                                                "Player terminated by signal {sig} (no output captured)."
+                                            ),
+                                            None => {
+                                                "Player exited with no output captured.".to_string()
+                                            }
+                                        }
+                                    }
+                                    #[cfg(not(unix))]
+                                    {
+                                        "Player exited with no output captured.".to_string()
+                                    }
+                                } else {
+                                    clean_error
+                                };
                                 sender
-                                    .send(Action::PlayerCrashed(status.code(), clean_error))
+                                    .send(Action::PlayerCrashed(status.code(), message))
                                     .ok();
                             } else {
                                 sender.send(Action::ReconcileHistory).ok();
 
                                 if let Some(item) = history_item {
                                     let elapsed = start_time.elapsed().as_secs();
-                                    if elapsed >= 30 {
-                                        let duration = item.duration_seconds;
+                                    let duration = item.duration_seconds;
+                                    // Without a known duration we can't tell playback time
+                                    // from time spent paused/buffering, so `start + elapsed`
+                                    // isn't trustworthy; skip saving rather than risk the
+                                    // resume point drifting past the end of the file.
+                                    if elapsed >= 30
+                                        && let Some(d) = duration
+                                    {
                                         let start_pos = resume_seconds.unwrap_or(0);
-                                        let total_pos = start_pos.saturating_add(elapsed);
-                                        let progress = if let Some(d) = duration {
-                                            total_pos.min(d)
-                                        } else {
-                                            total_pos
-                                        };
-                                        let completed = duration.is_some_and(|d| {
-                                            d > 0 && progress >= (d as f64 * 0.90) as u64
-                                        });
+                                        let progress = start_pos.saturating_add(elapsed).min(d);
+                                        let completed =
+                                            d > 0 && progress >= (d as f64 * 0.90) as u64;
                                         sender
                                             .send(Action::UpdateProgress {
                                                 item,


### PR DESCRIPTION
## What does this PR do?

- Prefer English audio and subtitle tracks by default in mpv/IINA/VLC when a multi-language release is muxed into a single file (e.g. Hindi + English), instead of silently falling back to whichever track is first in the container.
- Fix player-crash reporting so a crash is surfaced whenever the player exits non-zero. Previously it only fired within the first 3 seconds of launch and only when stderr had output, so a crash later in playback (e.g. triggered by a seek) with no captured stderr was silently treated as a normal exit.
- Fix an unbounded resume-progress bug: progress was computed as `previous_start + elapsed` with no upper bound when the file's duration was unknown, so it could grow past the actual runtime across repeated launches. Observed in practice: `progress_seconds` reached ~14996 for a ~53 minute episode, causing every subsequent resume to seek past end-of-file. Progress is now only persisted once duration is known, and clamped to it.

## Checklist

- [x] `cargo fmt --check` succeeds
- [x] `cargo clippy --all-targets --locked -- -D warnings` succeeds
- [x] `cargo check --locked` succeeds
- [x] Docs updated if this changes features, keybindings, or usage
- [x] `cargo test` passes (full suite)
- [x] Manually verified on a fourkhdhub multi-audio release (IINA): English audio and English subtitles both selected correctly with the built release binary

> Formatting and linting are enforced automatically by the pre-commit hook and CI.